### PR TITLE
Hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,18 @@ Another trivial/toy Lisp implementation in Go.
 
 Although this implementation is clearly derived from the [make a lisp](https://github.com/kanaka/mal/) series there are a couple of areas where we've implemented special/unusual things:
 
-* Type checking for function parameters
-  * Via a `:type` suffix.  For example `(lambda (a:string b:number) ..`.
+* Access to command-line arguments, when used via a shebang.
+  * See [args.lisp](args.lisp) for an example.
+* Introspection via the `(env)` function, which will return details of all variables/functions in the environment.
+  * Allowing dynamic invocation shown in [dynamic.lisp](dynamic.lisp) and other neat things.
 * Optional parameters for functions.
   * Any parameter which is prefixed by `&` is optional.
   * If not specified then `nil` is assumed.
-* Access to command-line arguments, when used via a shebang.
-  * See [args.lisp](args.lisp) for an example.
+* Support for hashes as well as lists.
+  * A hash looks like this `{ :name "Steve" :location "Helsinki" }`
+  * `(print (type { :foo "bar" } ))` -> "hash"
+* Type checking for function parameters.
+  * Via a `:type` suffix.  For example `(lambda (a:string b:number) ..`.
 
 
 Here's what the optional parameters look like in practice:
@@ -163,6 +168,9 @@ We have a reasonable number of functions implemented in our golang core:
 
 * Support for strings, numbers, errors, lists, etc.
   * `#t` is the true symbol, `#f` is false, though `true` and `false` are synonyms.
+* Hash operations:
+  * Hashes are literals like this `{ :name "Steve" :location "Helsinki" }`
+  * Keys can be retrieved/updated via `get`, & `set`.
 * List operations:
   * `car`, `cdr`, `list`, & `sort`.
 * Logical operations
@@ -176,7 +184,7 @@ We have a reasonable number of functions implemented in our golang core:
 * Misc features
   * `error`, `str`, `print`, & `type`
 * Special forms
-  * `begin`, `cond`, `define`, `eval`, `if`, `lambda`, `let`, `read`, `set!`, `quote`,
+  * `begin`, `cond`, `define`, `env`, `eval`, `if`, `lambda`, `let`, `read`, `set!`, `quote`,
 * Tail recursion optimization.
 
 Building upon those primitives we have a larger standard-library of functions written in Lisp such as:

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -7,9 +7,9 @@ import (
 	"math"
 	"os"
 	"sort"
-	"time"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/skx/yal/env"
 	"github.com/skx/yal/primitive"
@@ -61,9 +61,11 @@ func PopulateEnvironment(env *env.Environment) {
 
 	// core
 	env.Set("error", &primitive.Procedure{F: errorFn})
+	env.Set("get", &primitive.Procedure{F: getFn})
 	env.Set("getenv", &primitive.Procedure{F: getenvFn})
-	env.Set("now", &primitive.Procedure{F:nowFn})
+	env.Set("now", &primitive.Procedure{F: nowFn})
 	env.Set("print", &primitive.Procedure{F: printFn})
+	env.Set("set", &primitive.Procedure{F: setFn})
 	env.Set("sort", &primitive.Procedure{F: sortFn})
 	env.Set("sprintf", &primitive.Procedure{F: sprintfFn})
 
@@ -652,6 +654,41 @@ func orFn(args []primitive.Primitive) primitive.Primitive {
 	return primitive.Bool(false)
 }
 
+// getFn is the implementation of `(get hash key)`
+func getFn(args []primitive.Primitive) primitive.Primitive {
+
+	// We need two arguments
+	if len(args) != 2 {
+		return primitive.Error("invalid argument count")
+	}
+
+	// First is a Hash
+	if _, ok := args[0].(primitive.Hash); !ok {
+		return primitive.Error("argument not a hash")
+	}
+
+	tmp := args[0].(primitive.Hash)
+	return tmp.Get(args[1].ToString())
+}
+
+// setFn is the implementation of `(set hash key val)`
+func setFn(args []primitive.Primitive) primitive.Primitive {
+
+	// We need three arguments
+	if len(args) != 3 {
+		return primitive.Error("invalid argument count")
+	}
+
+	// First is a Hash
+	if _, ok := args[0].(primitive.Hash); !ok {
+		return primitive.Error("argument not a hash")
+	}
+
+	tmp := args[0].(primitive.Hash)
+	tmp.Set(args[1].ToString(), args[2])
+	return args[2]
+}
+
 // getenvFn is the implementation of `(getenv "PATH")`
 func getenvFn(args []primitive.Primitive) primitive.Primitive {
 
@@ -669,7 +706,6 @@ func getenvFn(args []primitive.Primitive) primitive.Primitive {
 	str := args[0].(primitive.String)
 	return primitive.String(os.Getenv(string(str)))
 }
-
 
 // nowFn is the implementation of `(now)`
 func nowFn(args []primitive.Primitive) primitive.Primitive {

--- a/builtins/builtins_test.go
+++ b/builtins/builtins_test.go
@@ -1,11 +1,11 @@
 package builtins
 
 import (
+	"math"
 	"os"
 	"strings"
 	"testing"
 	"time"
-	"math"
 
 	"github.com/skx/yal/env"
 	"github.com/skx/yal/primitive"
@@ -1527,8 +1527,107 @@ func TestNow(t *testing.T) {
 	// Get the current time
 	tm := time.Now().Unix()
 
-	if math.Abs( float64(tm - int64(e)) ) > 10 {
+	if math.Abs(float64(tm-int64(e))) > 10 {
 		t.Fatalf("weird result; (now) != now - outside our bound of ten seconds inaccuracy")
 	}
 
+}
+
+func TestGet(t *testing.T) {
+
+	// no arguments
+	out := getFn([]primitive.Primitive{})
+
+	// Will lead to an error
+	e, ok := out.(primitive.Error)
+	if !ok {
+		t.Fatalf("expected error, got %v", out)
+	}
+
+	// First argument must be a hash
+	out = getFn([]primitive.Primitive{
+		primitive.String("foo"),
+		primitive.String("foo"),
+	})
+
+	// Will lead to an error
+	e, ok = out.(primitive.Error)
+	if !ok {
+		t.Fatalf("expected error, got %v", out)
+	}
+	if !strings.Contains(string(e), "not a hash") {
+		t.Fatalf("got error, but wrong one %v", out)
+	}
+
+	// create a hash
+	h := primitive.Hash{}
+	h.Entries = make(map[string]primitive.Primitive)
+	h.Set("Name", primitive.String("STEVE"))
+
+	out2 := getFn([]primitive.Primitive{
+		h,
+		primitive.String("Name"),
+	})
+
+	// Will lead to a string
+	s, ok2 := out2.(primitive.String)
+	if !ok2 {
+		t.Fatalf("expected string, got %v", out2)
+	}
+	if !strings.Contains(string(s), "STEVE") {
+		t.Fatalf("got string, but wrong one %v", s)
+	}
+}
+
+func TestSet(t *testing.T) {
+
+	// no arguments
+	out := setFn([]primitive.Primitive{})
+
+	// Will lead to an error
+	e, ok := out.(primitive.Error)
+	if !ok {
+		t.Fatalf("expected error, got %v", out)
+	}
+
+	// First argument must be a hash
+	out = setFn([]primitive.Primitive{
+		primitive.String("foo"),
+		primitive.String("foo"),
+		primitive.String("foo"),
+	})
+
+	// Will lead to an error
+	e, ok = out.(primitive.Error)
+	if !ok {
+		t.Fatalf("expected error, got %v", out)
+	}
+	if !strings.Contains(string(e), "not a hash") {
+		t.Fatalf("got error, but wrong one %v", out)
+	}
+
+	// create a hash
+	h := primitive.Hash{}
+	h.Entries = make(map[string]primitive.Primitive)
+
+	out2 := setFn([]primitive.Primitive{
+		h,
+		primitive.String("Name"),
+		primitive.String("Steve"),
+	})
+
+	// Will lead to a string
+	s, ok2 := out2.(primitive.String)
+	if !ok2 {
+		t.Fatalf("expected string, got %v", out2)
+	}
+	if !strings.Contains(string(s), "Steve") {
+		t.Fatalf("got string, but wrong one %v", s)
+	}
+
+	// Now ensure the hash value was set
+	v := h.Get("Name")
+	if v.ToString() != "Steve" {
+		t.Fatalf("The value wasn't set?")
+	}
 }

--- a/builtins/builtins_test.go
+++ b/builtins/builtins_test.go
@@ -1543,6 +1543,9 @@ func TestGet(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
+	if !strings.Contains(string(e), "argument") {
+		t.Fatalf("got error, but wrong one")
+	}
 
 	// First argument must be a hash
 	out = getFn([]primitive.Primitive{
@@ -1588,6 +1591,9 @@ func TestSet(t *testing.T) {
 	e, ok := out.(primitive.Error)
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
+	}
+	if !strings.Contains(string(e), "argument") {
+		t.Fatalf("got error, but wrong one")
 	}
 
 	// First argument must be a hash

--- a/dynamic.lisp
+++ b/dynamic.lisp
@@ -4,7 +4,7 @@
 ;; Given the (string) name of a function to be called, and some
 ;; arguments .. call it.
 ;;
-;; (env) returns lists of lists, so we can find the function with
+;; (env) returns a lists of hashes, so we can find the function with
 ;; a given name via `filter`.  Assuming only one response then we're
 ;; able to find it by name, and execute it.
 ;;
@@ -15,14 +15,14 @@
           (fn  nil)) ; fn is the function of the result
 
       ;; find the entry in the list with the right name
-      (set! out (filter (env) (lambda (x) (eq (car x) name))))
+      (set! out (filter (env) (lambda (x) (eq (get x :name) name))))
 
       ;; there should be only one matching entry
       (if (= (length out) 1)
           (begin
-           (set! nm (car (car out)))        ;; nm == name
-           (set! fn (car (cdr (car out))))  ;; fn is the function to call
-           (if fn (fn args)))))))           ;; if we got it, invoke it
+           (set! nm (get (car out) :name))   ;; nm == name
+           (set! fn (get (car out) :value))  ;; fn is the function to call
+           (if fn (fn args)))))))            ;; if we got it, invoke it
 
 
 ;; Print a string

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -756,10 +756,12 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment) primitive.Prim
 									}
 
 									// Since we're calling `type` we need to
-									// do some rewriting for those two unusual cases
+									// do some rewriting for the function-case,
+									// which has distinct types.
 									if typ == "function" {
 										valid["procedure(lisp)"] = true
 										valid["procedure(golang)"] = true
+										valid["macro"] = true
 										continue
 									}
 

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -160,12 +160,56 @@ func (ev *Eval) readExpression() (primitive.Primitive, error) {
 		ev.offset++
 
 		return list, nil
-	case ")":
+	case "{":
+		// Are we at the end of our program?
+		if ev.offset >= len(ev.toks) {
+			return nil, ErrEOF
+		}
+
+		// Create a hash, which we'll populate with items
+		// until we reach the matching ")" statement
+		hash := primitive.Hash{}
+		hash.Entries = make(map[string]primitive.Primitive)
+
+		// Loop until we hit the closing bracket
+		for ev.toks[ev.offset] != "}" {
+
+			// Read the sub-expressions, recursively.
+			key, err := ev.readExpression()
+			if err != nil {
+				return nil, err
+			}
+
+			// Check again we've not hit the end of the program
+			if ev.offset >= len(ev.toks) {
+				return nil, ErrEOF
+			}
+
+			// Read the sub-expressions, recursively.
+			val, err2 := ev.readExpression()
+			if err2 != nil {
+				return nil, err2
+			}
+
+			// Check again we've not hit the end of the program
+			if ev.offset >= len(ev.toks) {
+				return nil, ErrEOF
+			}
+
+			hash.Set(key.ToString(), val)
+		}
+
+		// We bump the current read-position one more here,
+		// which means we skip over the closing "}" character.
+		ev.offset++
+
+		return hash, nil
+	case ")", "}":
 		// We shouldn't ever hit this, because we skip over
 		// the closing ")" when we handle "(".
 		//
 		// If a program is malformed we'll see it though
-		return nil, errors.New("unexpected ')'")
+		return nil, errors.New("unexpected '" + token + "'")
 	default:
 
 		// Return just a single atom/primitive.
@@ -258,6 +302,10 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment) primitive.Prim
 
 		// Strings return themselves
 		case primitive.String:
+			return exp
+
+		// Hashes return themselves
+		case primitive.Hash:
 			return exp
 
 		// Nil returns itself
@@ -512,9 +560,12 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment) primitive.Prim
 
 					v := val.(primitive.Primitive)
 
-					var tmp primitive.List
-					tmp = append(tmp, primitive.String(key))
-					tmp = append(tmp, v)
+					var tmp primitive.Hash
+					tmp.Entries = make(map[string]primitive.Primitive)
+
+					tmp.Set(":name", primitive.String(key))
+					tmp.Set(":value", v)
+
 					c = append(c, tmp)
 				}
 
@@ -616,9 +667,9 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment) primitive.Prim
 						evalArgExp := ev.eval(argExp, e)
 
 						// Was it an error?  Then abort
-						_, ok := evalArgExp.(primitive.Error)
+						x, ok := evalArgExp.(primitive.Error)
 						if ok {
-							return primitive.Error(fmt.Sprintf("error expanding argument %v for call to (%s ..)", argExp, listExp[0]))
+							return primitive.Error(fmt.Sprintf("error expanding argument %v for call to (%s ..): %s", argExp, listExp[0], x.ToString()))
 						}
 
 						// Otherwise append it to the list we'll supply

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -78,7 +78,7 @@ func TestEvaluate(t *testing.T) {
 		{":foo", ":foo"},
 
 		// hashes
-		{"{:age 34}", "{ :age:34}"},
+		{"{:age 34}", "{\n\t:age => 34\n}"},
 		{"(get {:age 34, :alive true} :alive)", "#t"},
 
 		// if

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -74,6 +74,13 @@ func TestEvaluate(t *testing.T) {
 		{"#f", "#f"},
 		{"false", "#f"},
 
+		// literals
+		{":foo", ":foo"},
+
+		// hashes
+		{"{:age 34}", "{ :age:34}"},
+		{"(get {:age 34, :alive true} :alive)", "#t"},
+
 		// if
 		{"(if true true false)", "#t"},
 		{"(if true true)", "#t"},
@@ -182,7 +189,7 @@ func TestEvaluate(t *testing.T) {
 		{"(lambda )}", "ERROR{wrong number of arguments}"},
 		{"(lambda 3 4)}", "ERROR{expected a list for arguments, got 3}"},
 		{"(define sq (lambda (x) (* x x))) (sq)", "ERROR{arity-error - function 'sq' requires 1 argument(s), 0 provided}"},
-		{"(print (/ 3 0))", "ERROR{error expanding argument [/ 3 0] for call to (print ..)}"},
+		{"(print (/ 3 0))", "ERROR{error expanding argument [/ 3 0] for call to (print ..): ERROR{attempted division by zero}}"},
 		{"(lambda (x 3) (nil))}", "ERROR{expected a symbol for an argument, got 3}"},
 		{"(set! )", "ERROR{arity-error: not enough arguments for (set! ..)}"},
 		{"(let )", "ERROR{arity-error: not enough arguments for (let ..)}"},
@@ -199,10 +206,17 @@ func TestEvaluate(t *testing.T) {
 
 		{"(read foo bar)", "ERROR{Expected only a single argument}"},
 		{"(read \")\")", "ERROR{failed to read ):unexpected ')'}"},
-		{"))))", "nil"},
+		{"(read \"}\")", "ERROR{failed to read }:unexpected '}'}"},
 		{"'", "nil"},
 		{"(3 3 ", "nil"},
 		{"(((((", "nil"},
+		{"))))", "nil"},
+		{"{{{{{{", "nil"},
+		{"{ ", "nil"},
+		{"{ :name ", "nil"},
+		{"{ :name { ", "nil"},
+		{"{ :age 333  ", "nil"},
+		{"}}}}}}", "nil"},
 
 		// type failures
 		{input: "(define blah (lambda (a:list) (print a))) (blah 3)", output: "ERROR{type-validation failed: argument a to blah was supposed to be list, got number}"},

--- a/primitive/hash.go
+++ b/primitive/hash.go
@@ -1,0 +1,32 @@
+package primitive
+
+// Hash holds a collection of other types, indexed by string
+type Hash struct {
+	Entries map[string]Primitive
+}
+
+// Get returns the value of a given index
+func (h Hash) Get(key string) Primitive {
+	return h.Entries[key]
+}
+
+// Set stores a value in the hash
+func (h Hash) Set(key string, val Primitive) {
+	h.Entries[key] = val
+}
+
+// ToString converts this object to a string.
+func (h Hash) ToString() string {
+
+	out := "{"
+	for k, v := range h.Entries {
+		out += " " + k + ":" + v.ToString()
+	}
+	out += "}"
+	return out
+}
+
+// Type returns the type of this primitive object.
+func (h Hash) Type() string {
+	return "hash"
+}

--- a/primitive/hash.go
+++ b/primitive/hash.go
@@ -18,9 +18,9 @@ func (h Hash) Set(key string, val Primitive) {
 // ToString converts this object to a string.
 func (h Hash) ToString() string {
 
-	out := "{"
+	out := "{\n"
 	for k, v := range h.Entries {
-		out += " " + k + ":" + v.ToString()
+		out += "\t" + k + " => " + v.ToString() + "\n"
 	}
 	out += "}"
 	return out

--- a/primitive/hash_test.go
+++ b/primitive/hash_test.go
@@ -1,0 +1,29 @@
+package primitive
+
+import "testing"
+
+func TestHash(t *testing.T) {
+
+	// Create a hash
+	h := Hash{}
+	h.Entries = make(map[string]Primitive)
+
+	out := h.Get("NAME")
+	if out != nil {
+		t.Fatalf("expected error getting hash value that is absent")
+	}
+
+	h.Set("NAME", String("ME"))
+	valid := h.Get("NAME")
+	if valid.ToString() != "ME" {
+		t.Fatalf("got wrong value")
+	}
+
+	if h.Type() != "hash" {
+		t.Fatalf("Wrong type for hash")
+	}
+
+	if h.ToString() != "{\n\tNAME => ME\n}" {
+		t.Fatalf("string value of hash was wrong")
+	}
+}

--- a/stdlib/stdlib.lisp
+++ b/stdlib/stdlib.lisp
@@ -13,6 +13,7 @@
 (define function? (lambda (x) (or (eq (type x) "procedure(lisp)")
                                   (eq (type x) "macro")
                                   (eq (type x) "procedure(golang)"))))
+(define hash?     (lambda (x) (eq (type x) "hash")))
 (define macro?    (lambda (x) (eq (type x) "macro")))
 (define list?     (lambda (x) (eq (type x) "list")))
 (define number?   (lambda (x) (eq (type x) "number")))


### PR DESCRIPTION
This pull-request adds support for hashes.  Hashes are like lists, but they are created between `{` and `}`, for example:

```lisp
(set! foo { :name "Steve" :location "Helsinki" } )
```

Once set you may access values via `get` and `set`.

The `(env)` function has been updated to return a list of hashes, with a pair of keys:

```
(print (env))
```

Will produce something like:

```lisp
(
  {
	:name => cons
	:value => #built-in-function
  } 
  {
	:name => get
	:value => #built-in-function
  }
  {
	:name => even?
	:value => (lambda (n) (zero? (% n 2)))
  } 
  ..
)
```