### PR TITLE
Added variadic support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Although this implementation is clearly derived from the [make a lisp](https://g
   * Via a `:type` suffix.  For example `(lambda (a:string b:number) ..`.
 * Support for macros.
   * See [mtest.lisp](mtest.lisp) for some simple tests/usage examples.
-  * The standard library uses macros, sparingly, for example to implement the `(cond)`, and `(while)` functions.
+  * The standard library uses macros to implement the `(cond)`, and `(while)` functions, for example.
 
 
 Here's an example of type-checking on a parameter value, in this case a list is required, via the `:list` suffix:

--- a/README.md
+++ b/README.md
@@ -29,23 +29,12 @@ Although this implementation is clearly derived from the [make a lisp](https://g
 * Support for hashes as well as lists/strings/numbers/etc.
   * A hash looks like this `{ :name "Steve" :location "Helsinki" }`
   * Sample code is visible in [hash.lisp](hash.lisp).
-* Optional parameters for functions.
-  * Any parameter which is prefixed by `&` is optional, and if not specified then `nil` is assumed.
 * Type checking for function parameters.
   * Via a `:type` suffix.  For example `(lambda (a:string b:number) ..`.
 * Support for macros.
   * See [mtest.lisp](mtest.lisp) for some simple tests/usage examples.
-  * The standard library uses macros, sparingly, for example to implement the `(while)` function.
+  * The standard library uses macros, sparingly, for example to implement the `(cond)`, and `(while)` functions.
 
-Here's what optional parameters, inspired by Emacs, look like in practice:
-
-```lisp
-(define foo (lambda (a &b &c)  (print "A:%s B:%s C:%s\n", a b c)))
-
-(foo 1 2 3)  ; => "A:1 B:2 C:3"
-(foo 1 2)    ; => "A:1 B:2 C:nil"
-(foo 1)      ; => "A:1 B:nil C:nil"
-```
 
 Here's an example of type-checking on a parameter value, in this case a list is required, via the `:list` suffix:
 
@@ -106,20 +95,18 @@ $ yal test.lisp
 A reasonable amount of sample code can be found in [test.lisp](test.lisp), but as a quick example we have a [fizzbuzz.lisp](fizzbuzz.lisp) sample:
 
 ```lisp
-;;
-;; This is a simple FizzBuzz example, which we can execute.
+;;; fizzbuzz.lisp - A simple FizzBuzz implementation.
+
 ;;
 ;; You'll see here that we can define functions, that we have
-;; primitives such as "zero?" and that we have a built-in "cond"
-;; function too.
+;; primitives such as "zero?" and that we have a "cond" funcion,
+;; implemented as a macro in our standard-library.
 ;;
 ;; cond here will take a list, which is processed in pairs:
 ;;
 ;;  (cond
-;;    (quote
 ;;      TEST1  ACTION1
 ;;      TEST2  ACTION2
-;;    )
 ;;  )
 ;;
 ;; For each pair (e.g. `TEST1 ACTION1`) we run the first statement, and if
@@ -128,9 +115,6 @@ A reasonable amount of sample code can be found in [test.lisp](test.lisp), but a
 ;; When the test returns nil/false/similar then we continue running until
 ;; we do get success.  That means it is important to end with something that
 ;; will always succeed.
-;;
-;; `(quote) is used to ensure we don't evaluate the list in advance of the
-;; statement.
 ;;
 
 ;; Is the given number divisible by 3?
@@ -148,16 +132,12 @@ A reasonable amount of sample code can be found in [test.lisp](test.lisp), but a
 (define divByFive  (lambda (n:number) (zero? (% n 5))))
 
 ;; Run the fizz-buzz test for the given number, N
-;;
-;; NOTE: `and` takes a list here.
-;;
 (define fizz (lambda (n:number)
   (cond
-    (quote
       (and (list (divByThree n) (divByFive n)))  (print "fizzbuzz")
       (divByThree n)                             (print "fizz")
       (divByFive  n)                             (print "buzz")
-      #t                                         (print n)))))
+      #t                                         (print n))))
 
 
 ;; Apply the function fizz, for each number 1-50
@@ -189,14 +169,14 @@ We have a reasonable number of functions implemented, either in our golang core 
 * Misc features:
   * `getenv`, `str`, `print`, & `type`
 * Special forms:
-  * `begin`, `cond`, `define`, `env`, `eval`, `gensym`, `if`, `lambda`, `let`, `macroexpand`, `read`, `set!`, `quote`, & `quasiquote`.
+  * `begin`, `define`, `env`, `eval`, `gensym`, `if`, `lambda`, `let`, `macroexpand`, `read`, `set!`, `quote`, & `quasiquote`.
 * Error handling:
   * `error`, `try`, and `catch` - as demonstrated in [try.lisp](try.lisp).
 * Tail recursion optimization.
 
 Building upon those primitives we have a larger standard-library of functions written in Lisp such as:
 
-* `abs`, `apply`, `append`, `filter`, `lower`, `map`, `min`, `max`, `nat`, `neg`, `now`, `nth`, `reduce`, `repeat`, `reverse`, `seq`, `upper`, `while`, etc.
+* `abs`, `apply`, `append`, `cond`, `filter`, `lower`, `map`, `min`, `max`, `nat`, `neg`, `now`, `nth`, `reduce`, `repeat`, `reverse`, `seq`, `upper`, `while`, etc.
 
 Although the lists above should be up to date you can check the definitions to see what is currently available:
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ We have a reasonable number of functions implemented, either in our golang core 
 
 Building upon those primitives we have a larger standard-library of functions written in Lisp such as:
 
-* `abs`, `apply`, `append`, `cond`, `filter`, `lower`, `map`, `min`, `max`, `nat`, `neg`, `now`, `nth`, `reduce`, `repeat`, `reverse`, `seq`, `upper`, `while`, etc.
+* `abs`, `apply`, `append`, `cond`, `filter`, `lower`, `map`, `min`, `max`, `nat`, `neg`, `now`, `nth`, `reduce`, `repeat`, `reverse`, `seq`, `upper`, `when`, `while`, etc.
 
 Although the lists above should be up to date you can check the definitions to see what is currently available:
 

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -916,18 +916,14 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 				//
 				var lst primitive.List
 
-				for _, x := range proc.Args {
-
-					// Minimum argument count is increased.
-					min++
-
-					// Is this variadic?
-					//
-					// Then save the name of the argument away.
-					//
-					if strings.HasPrefix(x.ToString(), "&") {
-						variadic = x.ToString()
-						variadic = strings.TrimPrefix(variadic, "&")
+				//
+				// Count the minimum number of arguments.
+				//
+				// A variadic argument may be nil of course.
+				//
+				for _, arg := range proc.Args {
+					if !strings.HasPrefix(arg.ToString(), "&") {
+						min++
 					}
 				}
 
@@ -953,8 +949,15 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 						// Get the parameter name
 						tmp := proc.Args[i].ToString()
 
-						// Strip off any "&" prefix
-						tmp = strings.TrimPrefix(tmp, "&")
+						// Is this variadic?
+						//
+						// Then save the name of the argument away, after removing
+						// the prefix
+						//
+						if strings.HasPrefix(tmp, "&") {
+							tmp = strings.TrimPrefix(tmp, "&")
+							variadic = tmp
+						}
 
 						// Does the argument have a trailing type?
 						if strings.Contains(tmp, ":") {
@@ -1004,7 +1007,9 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 						}
 
 						// And now set the value
-						e.Set(tmp, x)
+						if variadic == "" {
+							e.Set(tmp, x)
+						}
 
 					}
 

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -953,7 +953,7 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 						// Get the parameter name
 						tmp := proc.Args[i].ToString()
 
-						// Strip off any "&" or "#" prefix
+						// Strip off any "&" prefix
 						tmp = strings.TrimPrefix(tmp, "&")
 
 						// Does the argument have a trailing type?

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -708,59 +708,6 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 				}
 				return ret
 
-			// (cond
-			case primitive.Symbol("cond"):
-
-				// Cast the argument to a list
-				l := listExp[1].(primitive.List)
-
-				// skip the quote
-				l = l[1:]
-
-				// Iterate over the list in pairs
-				for i := 0; i < len(l); i += 2 {
-
-					var section []primitive.Primitive
-					if i > len(l)-2 {
-						section = l[i:]
-					} else {
-						section = l[i : i+2]
-					}
-
-					// Test that worked
-					if len(section) != 2 {
-						return primitive.Error("expected pairs of two items")
-					}
-
-					// The two parts of this section
-					test := section[0]
-					eval := section[1]
-
-					// need to eval test now.
-					res := ev.eval(test, e, expandMacro)
-
-					// If we got an error then we return
-					// it to our caller.
-					e, eok := res.(primitive.Error)
-					if eok {
-						return e
-					}
-
-					// Was it a success?  Then
-					// goto our exit.
-					//
-					// This is horrid, but it short-circuits
-					// the evaluation of the rest of the
-					// list-pairs.
-					if b, ok := res.(primitive.Bool); ok && bool(b) {
-						// we'll execute this statement
-						// when we return
-						exp = eval
-						goto repeat_eval
-					}
-
-				}
-
 			// (env
 			case primitive.Symbol("env"):
 
@@ -958,17 +905,38 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 				// themselves.
 				//
 				min := 0
+
+				//
+				// if this is non-empty then we add all parameters here as a llist
+				//
+				variadic := ""
+
+				//
+				// The list of arguments to add when working in a variadic fashion
+				//
+				var lst primitive.List
+
 				for _, x := range proc.Args {
-					if !strings.HasPrefix(x.ToString(), "&") {
-						min++
+
+					// Minimum argument count is increased.
+					min++
+
+					// Is this variadic?
+					//
+					// Then save the name of the argument away.
+					//
+					if strings.HasPrefix(x.ToString(), "&") {
+						variadic = x.ToString()
+						variadic = strings.TrimPrefix(variadic, "&")
 					}
 				}
 
 				//
-				// Check that the arguments supplied
-				// match those that are expected.
+				// Check that the arguments supplied match those that are expected.
 				//
-				if len(args) < min {
+				// Unless variadic arguments are expected, because in that case "anything" is fine.
+				//
+				if len(args) < min && (variadic == "") {
 					return primitive.Error(fmt.Sprintf("arity-error - function '%s' requires %d argument(s), %d provided", listExp[0].ToString(), min, len(args)))
 				}
 
@@ -985,11 +953,10 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 						// Get the parameter name
 						tmp := proc.Args[i].ToString()
 
-						// Strip off any "&" prefix
+						// Strip off any "&" or "#" prefix
 						tmp = strings.TrimPrefix(tmp, "&")
 
-						// Does the argument have
-						// a trailing type?
+						// Does the argument have a trailing type?
 						if strings.Contains(tmp, ":") {
 
 							before, after, found := strings.Cut(tmp, ":")
@@ -1038,13 +1005,28 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 
 						// And now set the value
 						e.Set(tmp, x)
+
+					}
+
+					// Variadic arguments?  Then save this arg away
+					if len(variadic) > 0 {
+						lst = append(lst, x)
 					}
 				}
 
-				// Here we go round the loop again.
+				// For variadic arguments we can't set the value as we go,
+				// because we have to wait until we've collected them all.
 				//
-				// Which will execute the body of the function
-				// this time.
+				// So set them now.
+				if len(variadic) > 0 {
+					e.Set(variadic, lst)
+				}
+
+				// Here we go round the evaluation loop again.
+				//
+				// Which will execute the body of the function this time.
+				//
+				// TCO.
 				exp = proc.Body
 			}
 		}

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -193,6 +193,12 @@ a
     true     "small")`,
 			"small"},
 
+		{"(cond true 7 true 8)", "7"},
+		{"(cond false 7 true 8)", "8"},
+		{"(cond false 7 false 8 \"else\" 9)", "9"},
+		{"(cond false 7 (= 2 2) 8 \"else\" 9)", "8"},
+		{"(cond false 7 false 8 false 9)", "nil"},
+
 		// maths
 		{"(+ 3 1)", "4"},
 		{"(- 3 1)", "2"},

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -2,6 +2,7 @@ package eval
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -184,10 +185,14 @@ a
 		// cond
 		{`(define a 44)
  (cond
-  (quote
     (> a 20) "big"
-    true     "fallback"))`,
+    true     "small")`,
 			"big"},
+		{`(define a 4)
+ (cond
+    (> a 20) "big"
+    true     "small")`,
+			"small"},
 
 		// maths
 		{"(+ 3 1)", "4"},
@@ -237,7 +242,6 @@ a
 		{"(let ((0 0)) )", "ERROR{binding name is not a symbol, got 0}"},
 		{"(let ((0 )) )", "ERROR{arity-error: binding list had missing arguments}"},
 		{"(let (3 3) )", "ERROR{binding value is not a list, got 3}"},
-		{"(cond (quote 3))", "ERROR{expected pairs of two items}"},
 		{"(error )", "ERROR{arity-error: not enough arguments for (error}"},
 		{"(quote )", "ERROR{arity-error: not enough arguments for (quote}"},
 		{"(quasiquote )", "ERROR{arity-error: not enough arguments for (quasiquote}"},
@@ -256,12 +260,10 @@ a
 		{`
 (define fizz (lambda (n:number)
   (cond
-    (quote
       (/ n 0)  (print "fizzbuzz")
-      #t       (print n)))))
+      #t       (print n))))
 
 (fizz 3)
-
 `, "ERROR{attempted division by zero}"},
 		{"(error \"CAKE-FAIL\")", "ERROR{CAKE-FAIL}"},
 
@@ -308,6 +310,8 @@ a
 
 		// Populate the default primitives
 		builtins.PopulateEnvironment(env)
+
+		fmt.Printf("Running:%s\n", test.input)
 
 		// Run it
 		out := l.Evaluate(env)

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -2,7 +2,6 @@ package eval
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -298,28 +297,28 @@ a
 
 	for _, test := range tests {
 
-		// Load our standard library
-		st := stdlib.Contents()
-		std := string(st)
+		t.Run(test.input, func(t *testing.T) {
 
-		// Create a new interpreter
-		l := New(std + "\n" + test.input)
+			// Load our standard library
+			st := stdlib.Contents()
+			std := string(st)
 
-		// With a new environment
-		env := env.New()
+			// Create a new interpreter
+			l := New(std + "\n" + test.input)
 
-		// Populate the default primitives
-		builtins.PopulateEnvironment(env)
+			// With a new environment
+			env := env.New()
 
-		fmt.Printf("Running:%s\n", test.input)
+			// Populate the default primitives
+			builtins.PopulateEnvironment(env)
 
-		// Run it
-		out := l.Evaluate(env)
+			// Run it
+			out := l.Evaluate(env)
 
-		if out.ToString() != test.output {
-			t.Fatalf("test '%s' should have produced '%s', but got '%s'", test.input, test.output, out.ToString())
-		}
-
+			if out.ToString() != test.output {
+				t.Fatalf("test '%s' should have produced '%s', but got '%s'", test.input, test.output, out.ToString())
+			}
+		})
 	}
 }
 
@@ -378,25 +377,28 @@ func TestStandardLibrary(t *testing.T) {
 
 	for _, test := range tests {
 
-		// Load our standard library
-		st := stdlib.Contents()
-		std := string(st)
+		t.Run(test.input, func(t *testing.T) {
 
-		// Create a new interpreter
-		l := New(std + "\n" + test.input)
+			// Load our standard library
+			st := stdlib.Contents()
+			std := string(st)
 
-		// With a new environment
-		env := env.New()
+			// Create a new interpreter
+			l := New(std + "\n" + test.input)
 
-		// Populate the default primitives
-		builtins.PopulateEnvironment(env)
+			// With a new environment
+			env := env.New()
 
-		// Run it
-		out := l.Evaluate(env)
+			// Populate the default primitives
+			builtins.PopulateEnvironment(env)
 
-		if out.ToString() != test.output {
-			t.Fatalf("test '%s' should have produced '%s', but got '%s'", test.input, test.output, out.ToString())
-		}
+			// Run it
+			out := l.Evaluate(env)
+
+			if out.ToString() != test.output {
+				t.Fatalf("test '%s' should have produced '%s', but got '%s'", test.input, test.output, out.ToString())
+			}
+		})
 
 	}
 }

--- a/fizzbuzz.lisp
+++ b/fizzbuzz.lisp
@@ -2,16 +2,14 @@
 
 ;;
 ;; You'll see here that we can define functions, that we have
-;; primitives such as "zero?" and that we have a built-in "cond"
-;; function too.
+;; primitives such as "zero?" and that we have a "cond" funcion,
+;; implemented as a macro in our standard-library.
 ;;
 ;; cond here will take a list, which is processed in pairs:
 ;;
 ;;  (cond
-;;    (quote
 ;;      TEST1  ACTION1
 ;;      TEST2  ACTION2
-;;    )
 ;;  )
 ;;
 ;; For each pair (e.g. `TEST1 ACTION1`) we run the first statement, and if
@@ -20,9 +18,6 @@
 ;; When the test returns nil/false/similar then we continue running until
 ;; we do get success.  That means it is important to end with something that
 ;; will always succeed.
-;;
-;; `(quote) is used to ensure we don't evaluate the list in advance of the
-;; statement.
 ;;
 
 ;; Is the given number divisible by 3?
@@ -42,11 +37,10 @@
 ;; Run the fizz-buzz test for the given number, N
 (define fizz (lambda (n:number)
   (cond
-    (quote
       (and (list (divByThree n) (divByFive n)))  (print "fizzbuzz")
       (divByThree n)                             (print "fizz")
       (divByFive  n)                             (print "buzz")
-      #t                                         (print n)))))
+      #t                                         (print n))))
 
 
 ;; Apply the function fizz, for each number 1-50

--- a/mtest.lisp
+++ b/mtest.lisp
@@ -168,23 +168,6 @@
 ;;
 
 
-;;
-;; Define a simple "unless" macro, with a mandatory case and
-;; an optional one.
-;;
-(define unless (macro (pred a &b) `(if (! ~pred) ~a ~b)))
-
-;;
-;; Use that to operate a series of expressions.
-;;
-(unless false (list
-               (print "unless-test one")
-               (print "unless-test two")
-               (print "unless-test three")))
-
-(unless true (print "FAIL") (print "OK - (unless ..) is good"))
-(unless false (print "OK - (unless ..) is good.") (print "FAIL"))
-
 
 ;;
 ;; if2 is a simple macro which allows you to run two actions if an
@@ -201,6 +184,9 @@
 ;; The downside here is that you don't get a negative branch, but running
 ;; two things is very common - see for example the "(while)" and "(repeat)"
 ;; macros in our standard library.
+;;
+;; See also "(when) in the standard-library, which allows a list of operations
+;; when a condition is true rather than two, and only two.
 ;;
 (define if2 (macro (pred one two)
   `(if ~pred (begin ~one ~two))))

--- a/stdlib/stdlib.lisp
+++ b/stdlib/stdlib.lisp
@@ -113,6 +113,17 @@
 
 
 ;;
+;; Run an arbitrary series of statements, if the given condition is true.
+;;
+;; This is the more general/useful version of the "if2" macro, given above.
+;;
+;; Sample usage:
+;;
+;;  (when (= 1 1) (print "OK") (print "Still OK") (print "final statement"))
+;;
+(define when (macro (pred &rest) `(if ~pred (begin ~@rest))))
+
+;;
 ;; Part of our while-implementation.
 ;; If the specified predicate is true, then run the body.
 ;;

--- a/stdlib/stdlib.lisp
+++ b/stdlib/stdlib.lisp
@@ -136,6 +136,17 @@
                            (list 'lambda '() body))))
 
 
+;;
+;; cond is a useful thing to have.
+;;
+(define cond (macro (&xs)
+  (if (> (length xs) 0)
+      (list 'if (first xs)
+            (if (> (length xs) 1)
+                (nth xs 1)
+              (error "An odd number of forms to (cond..)"))
+            (cons 'cond (rest (rest xs)))))))
+
 ;; Setup a simple function to run a loop N times
 ;;
 ;; NOTE: We use "if2" not "if".

--- a/test.lisp
+++ b/test.lisp
@@ -172,11 +172,10 @@
 ;; Simple test of `cond`
 (define a 6)
 (cond
-  (quote
     (> a 20) (print "A > 20")
     (> a 15) (print "A > 15")
     true     (print "A is %s" a)
-))
+)
 
 ;;
 ;; Trivial Read/Eval pair


### PR DESCRIPTION
This pull-request removes "optional" parameters for functions/macros, in preference to the more standard "&rest" support for swallowing up a variable number of arguments.

Once this vararg support landed rewriting the "(cond)" special form as a standard macro became possible - proving it was a good idea.

So:

* Optional parameters, inspired by emacs, prefixed with "&" are removed.
* Variadic arguments are supported.
* Using the variadic parameter, now available, (cond..) was reimplemented as a macro, rather than in golang.

As our (cond) macro is now more standard its use is now more standard, and the needless quote was removed from its use in the [fizzbuzz.lisp](fizzbuzz.lisp) example.

This closes #5.