### PR TITLE
Work towards MAL compatability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 # yet another lisp
 
-Another trivial/toy Lisp implementation in Go.
+Another trivial/toy Lisp implementation in Go - there is obviously a lot of MAL-history here, and so you should expect that most things will work in a similar fashion.
 
 
 ## Special Features
@@ -180,6 +180,11 @@ We have a reasonable number of functions implemented, either in our golang core 
 * Error handling:
   * `error`, `try`, and `catch` - as demonstrated in [try.lisp](try.lisp).
 * Tail recursion optimization.
+* MAL compatability:
+  * `fn*` can be used as a synonym for `lambda`.
+  * `def!` can be used as a synonym for `define`.
+  * `defmacro!` is used to define macros.
+
 
 Building upon those primitives we have a larger standard-library of functions written in Lisp such as:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 # yet another lisp
 
-Another trivial/toy Lisp implementation in Go - there is obviously a lot of MAL-history here, and so you should expect that most things will work in a similar fashion.
+Another trivial/toy Lisp implementation in Go.
 
 
 ## Special Features

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -861,17 +861,16 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 					args = append(args, xs)
 				}
 
-				// Macro?
-				macro := false
-				if listExp[0].ToString() == "macro" {
-					macro = true
-				}
-
+				// This is a procedure, which will default
+				// to not being a macro.
+				//
+				// To make it a macro it should be set with
+				// "(defmacro!..)"
 				return &primitive.Procedure{
 					Args:  args,
 					Body:  listExp[2],
 					Env:   e,
-					Macro: macro,
+					Macro: false,
 				}
 
 			// Anything else is either a built-in function,

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -606,7 +606,7 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 				}
 
 			// (define
-			case primitive.Symbol("define"):
+			case primitive.Symbol("define"), primitive.Symbol("def!"):
 				if len(listExp) < 3 {
 					return primitive.Error("arity-error: not enough arguments for (define ..)")
 				}
@@ -618,6 +618,31 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 					return primitive.Nil{}
 				}
 				return primitive.Error(fmt.Sprintf("Expected a symbol, got %v", listExp[1]))
+
+			// (defmacro!
+			case primitive.Symbol("defmacro!"):
+				if len(listExp) < 3 {
+					return primitive.Error("arity-error: not enough arguments for (defmacro! ..)")
+				}
+
+				// name of macro
+				symb, ok := listExp[1].(primitive.Symbol)
+				if !ok {
+					return primitive.Error(fmt.Sprintf("Expected a symbol, got %v", listExp[1]))
+				}
+
+				// macro body
+				val := ev.eval(listExp[2], e, expandMacro)
+
+				mac, ok2 := val.(*primitive.Procedure)
+				if !ok2 {
+					return primitive.Error(fmt.Sprintf("expected a function body for (defmacro..), got %v", val))
+				}
+
+				// this is now a macro
+				mac.Macro = true
+				e.Set(string(symb), mac)
+				return primitive.Nil{}
 
 			// (set!
 			case primitive.Symbol("set!"):
@@ -812,7 +837,7 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 				return ev.eval(blkLst[2], tmpEnv, expandMacro)
 
 			// (lambda
-			case primitive.Symbol("lambda"), primitive.Symbol("macro"):
+			case primitive.Symbol("lambda"), primitive.Symbol("fn*"):
 
 				// ensure we have arguments
 				if len(listExp) < 3 {

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -89,7 +89,7 @@ func TestEvaluate(t *testing.T) {
 		{"(if false false)", "nil"},
 
 		// macroexpand - args are not evaluated
-		{`(define foo (macro (x) x)) (macroexpand (foo (+ 1 2)))`, "(+ 1 2)"},
+		{`(defmacro! foo (fn* (x) x)) (macroexpand (foo (+ 1 2)))`, "(+ 1 2)"},
 		// quote
 		{`(define lst (quote (b c)))
                   '(a lst d)`, "(a lst d)"},
@@ -105,7 +105,7 @@ func TestEvaluate(t *testing.T) {
 			"(a b c d)"},
 
 		// expand a macro
-		{`(define steve (macro () "steve"))
+		{`(defmacro! steve (fn* () "steve"))
                   (macroexpand (steve))`,
 			"steve"},
 

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -273,6 +273,10 @@ a
 `, "ERROR{attempted division by zero}"},
 		{"(error \"CAKE-FAIL\")", "ERROR{CAKE-FAIL}"},
 
+		{"(defmacro!)", "ERROR{arity-error: not enough arguments for (defmacro! ..)}"},
+		{"(defmacro! 1 2)", "ERROR{Expected a symbol, got 1}"},
+		{"(defmacro! foo 2)", "ERROR{expected a function body for (defmacro..), got 2}"},
+
 		{"(read foo bar)", "ERROR{Expected only a single argument}"},
 		{"(read \")\")", "ERROR{failed to read ):unexpected ')'}"},
 		{"(read \"}\")", "ERROR{failed to read }:unexpected '}'}"},

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -93,7 +93,7 @@ func FuzzYAL(f *testing.F) {
 
 	// Macros
 	f.Add([]byte(`
-(define unless (macro (pred a &b) ` + "`" + `(if (! ~pred) ~a ~b)))
+(defmacro! unless (fn* (pred a &b) ` + "`" + `(if (! ~pred) ~a ~b)))
 (unless false (print "OK")
 `))
 

--- a/mtest.lisp
+++ b/mtest.lisp
@@ -16,7 +16,7 @@
 ;; Here is our first macro, given a variable-name show both the
 ;; name and the current value.
 ;;
-(define debug (macro (x) `(print "Variable '%s' has value %s" '~x ~x)))
+(defmacro! debug (fn* (x) `(print "Variable '%s' has value %s" '~x ~x)))
 (debug lst)
 
 ;;
@@ -26,7 +26,7 @@
 ;; we both evaluate it, and show it literally (in the case where things
 ;; failed).
 ;;
-(define assert (macro (exp)
+(defmacro! assert (fn* (exp)
                       `(if ~exp
                          ()
                            (print "Assertion failed: %s" `~exp))))
@@ -58,7 +58,7 @@
 ;;
 ;;        We'll refine to fix this.
 ;;
-(define set2! (macro (v1 v2 e)
+(defmacro! set2! (fn* (v1 v2 e)
                      `(begin
                        (set! ~v1 ~e)
                        (set! ~v2 ~e))))
@@ -80,7 +80,7 @@
 ;;       The "(set!..)" calls operate in a new scope.  So they can't modify
 ;;       the global environment.
 ;;
-(define set2! (macro (v1 v2 e)
+(defmacro! set2! (fn* (v1 v2 e)
                      (let ((tmp (gensym)))
                        `(begin (let ((~tmp ~e))
                            (set! ~v1 ~tmp)
@@ -94,7 +94,7 @@
 ;; The difference here is we use the three-argument form of the (set!..)
 ;; form, to update the global/parent scope.
 ;;
-(define set2! (macro (v1 v2 e)
+(defmacro! set2! (fn* (v1 v2 e)
                      (let ((tmp (gensym)))
                        `(begin (let ((~tmp ~e))
                            (set! ~v1 ~tmp true)
@@ -170,14 +170,14 @@
 ;; See also "(when) in the standard-library, which allows a list of operations
 ;; when a condition is true rather than two, and only two.
 ;;
-(define if2 (macro (pred one two)
+(defmacro! if2 (fn* (pred one two)
   `(if ~pred (begin ~one ~two))))
 
 
 ;;
 ;; Increment the given variable by one.
 ;;
-(define incr (macro (x) `(set! ~x (+ ~x 1))))
+(defmacro! incr (fn* (x) `(set! ~x (+ ~x 1))))
 
 ;;
 ;; Show macro expansion
@@ -199,7 +199,7 @@
 
 
 ;; Type of a macro is "macro"
-(define truthy (macro () true))
+(defmacro! truthy (fn* () true))
 (print "The type of a macro is (type truthy):%s" (type truthy))
 
 ;; The macro? predicate will recognize one too.

--- a/stdlib/stdlib.lisp
+++ b/stdlib/stdlib.lisp
@@ -74,8 +74,8 @@
 (define dec  (lambda (n:number) (- n 1)))
 
 ;; We could also define the incr/decr operations as macros.
-(define incr (macro (x) `(set! ~x (+ ~x 1))))
-(define decr (macro (x) `(set! ~x (- ~x 1))))
+(defmacro! incr (fn* (x) `(set! ~x (+ ~x 1))))
+(defmacro! decr (fn* (x) `(set! ~x (- ~x 1))))
 
 ;; Not is useful
 (define !     (lambda (x) (if x #f #t)))
@@ -108,7 +108,7 @@
 ;; two things is very common - see for example the "(while)" and "(repeat)"
 ;; macros later in this file.
 ;;
-(define if2 (macro (pred one two)
+(defmacro! if2 (fn* (pred one two)
   `(if ~pred (begin ~one ~two))))
 
 
@@ -121,7 +121,7 @@
 ;;
 ;;  (when (= 1 1) (print "OK") (print "Still OK") (print "final statement"))
 ;;
-(define when (macro (pred &rest) `(if ~pred (begin ~@rest))))
+(defmacro! when (fn* (pred &rest) `(if ~pred (begin ~@rest))))
 
 ;;
 ;; Part of our while-implementation.
@@ -141,7 +141,7 @@
 ;;
 ;; NOTE: We use "if2" not "if".
 ;;
-(define while (macro (expression body)
+(defmacro! while (fn* (expression body)
                      (list 'while-fun
                            (list 'lambda '() expression)
                            (list 'lambda '() body))))
@@ -150,7 +150,7 @@
 ;;
 ;; cond is a useful thing to have.
 ;;
-(define cond (macro (&xs)
+(defmacro! cond (fn* (&xs)
   (if (> (length xs) 0)
       (list 'if (first xs)
             (if (> (length xs) 1)


### PR DESCRIPTION
This pull-request allows the following two lines of lisp to execute, as expected:

     (def! sum2 (fn* (n acc) (if (= n 0) acc (sum2 (- n 1) (+ n acc)))))
     (defmacro! unless (fn* (pred a b) `(if ~pred ~b ~a)))

This means we needed to change:

     (define unless (macro (pred ...)))

Now "fn*" is a synonym for "lambda", and "def!" is a synonym for define.

We've added an explicit "defmacro!" handler, which will cooerce the value into a macro.

This updates #7.

Test cases are updated, and standard library.

* TODO
  * [x] Update README.md
  * [x] Add explicit test-cases.
