### PR TITLE
Remove "(begin)", replace it with "(do)".

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,11 @@ We have a reasonable number of functions implemented, either in our golang core 
 * Misc features:
   * `arch`, `getenv`, `os`, `print`, `slurp`, `sprintf`, `str` & `type`
 * Special forms:
-  * `begin`, `define`, `do`, `env`, `eval`, `gensym`, `if`, `lambda`, `let`, `macroexpand`, `read`, `set!`, `quote`, & `quasiquote`.
+  * `define`, `do`, `env`, `eval`, `gensym`, `if`, `lambda`, `let`, `macroexpand`, `read`, `set!`, `quote`, & `quasiquote`.
 * Error handling:
   * `error`, `try`, and `catch` - as demonstrated in [try.lisp](try.lisp).
 * Tail recursion optimization.
 * MAL compatability:
-  * `do` can be used as a synonym for `begin`.
   * `def!` can be used as a synonym for `define`.
   * `defmacro!` is used to define macros.
   * `fn*` can be used as a synonym for `lambda`.

--- a/dynamic.lisp
+++ b/dynamic.lisp
@@ -26,7 +26,7 @@
 
       ;; there should be only one matching entry
       (if (= (length out) 1)
-          (begin
+          (do
            (set! nm (get (car out) :name))   ;; nm == name
            (set! fn (get (car out) :value))  ;; fn is the function to call
            (if fn (fn args)))))))            ;; if we got it, invoke it

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -508,8 +508,8 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 			// first token/symbol
 			switch listExp[0] {
 
-			// (begin ..) | (do ..)
-			case primitive.Symbol("begin"), primitive.Symbol("do"):
+			// (do ..)
+			case primitive.Symbol("do"):
 				var ret primitive.Primitive
 				for _, x := range listExp[1:] {
 					ret = ev.eval(x, e, expandMacro)

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -19,7 +19,7 @@ func TestTimeout(t *testing.T) {
 	tst := `
 (set! a 1)
 (while true
- (begin
+ (do
    (set! a (+ a 1) true)))
 `
 	// Load our standard library
@@ -157,7 +157,7 @@ a
 		{"()", "()"},
 		{"(car '(1 2 3))", "1"},
 		{"(cdr '(1 2 3))", "(2 3)"},
-		{"(begin 1 2)", "2"},
+		{"(do 1 2)", "2"},
 
 		// numbers
 		{"3", "3"},

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -49,7 +49,7 @@ func FuzzYAL(f *testing.F) {
 	f.Add([]byte(`
 ; Split a string into a list, reverse it, and join it
 (let* (input "Steve Kemp")
-  (begin
+  (do
    (print "Starting string: %s" input)
    (print "Reversed string: %s" (join (reverse (split "Steve Kemp" ""))))))
 `))

--- a/hash.lisp
+++ b/hash.lisp
@@ -55,6 +55,6 @@
 (print "Values in the environment matching the regexp /int/\n%s" out)
 
 ;;
-(apply out (lambda (x) (begin
+(apply out (lambda (x) (do
                         (print "Function in env. matching regexp /int/")
                         (print "\t%s" (get x :name)))))

--- a/mtest.lisp
+++ b/mtest.lisp
@@ -46,7 +46,7 @@
 ;;
 ;; We want to treat it as:
 ;:
-;;    (begin
+;;    (do
 ;;      (set! v1 e)
 ;;      (set! v2 e)
 ;;    )
@@ -59,7 +59,7 @@
 ;;        We'll refine to fix this.
 ;;
 (defmacro! set2! (fn* (v1 v2 e)
-                     `(begin
+                     `(do
                        (set! ~v1 ~e)
                        (set! ~v2 ~e))))
 
@@ -67,7 +67,7 @@
 ;;
 ;; You can see this in the following code:
 ;;
-;;   (set2! a c (begin (print "EXECUTED TWICE!") (+ 32 23)))
+;;   (set2! a c (do (print "EXECUTED TWICE!") (+ 32 23)))
 
 ;;
 ;; The second attempt would use a temporary variable to store the new
@@ -82,7 +82,7 @@
 ;;
 (defmacro! set2! (fn* (v1 v2 e)
                      (let* (tmp (gensym))
-                       `(begin (let* (~tmp ~e)
+                       `(do (let* (~tmp ~e)
                            (set! ~v1 ~tmp)
                            (set! ~v2 ~tmp))))))
 
@@ -96,7 +96,7 @@
 ;;
 (defmacro! set2! (fn* (v1 v2 e)
                      (let* (tmp (gensym))
-                       `(begin (let* (~tmp ~e)
+                       `(do (let* (~tmp ~e)
                            (set! ~v1 ~tmp true)
                            (set! ~v2 ~tmp true))))))
 
@@ -133,7 +133,7 @@
 ;;
 ;; NOTE This expression is only evaluated once, which is what we wanted.
 ;;
-(set2! a c (begin (print "ONLY EXECUTED ONCE!") (+ 32 23)))
+(set2! a c (do (print "ONLY EXECUTED ONCE!") (+ 32 23)))
 
 ;;
 ;; So the values will be changed, again.
@@ -159,9 +159,9 @@
 ;;
 ;;   (if2 true (print "1") (print "2"))
 ;;
-;; Instead of having to add (begin:
+;; Instead of having to add (do:
 ;;
-;;   (if true (begin (print "1") (print "2")))
+;;   (if true (do (print "1") (print "2")))
 ;;
 ;; The downside here is that you don't get a negative branch, but running
 ;; two things is very common - see for example the "(while)" and "(repeat)"
@@ -171,7 +171,7 @@
 ;; when a condition is true rather than two, and only two.
 ;;
 (defmacro! if2 (fn* (pred one two)
-  `(if ~pred (begin ~one ~two))))
+  `(if ~pred (do ~one ~two))))
 
 
 ;;

--- a/stdlib/stdlib.lisp
+++ b/stdlib/stdlib.lisp
@@ -105,16 +105,16 @@
 ;;
 ;;   (if2 true (print "1") (print "2"))
 ;;
-;; Instead of having to use (begin), like so:
+;; Instead of having to use (do), like so:
 ;;
-;;   (if true (begin (print "1") (print "2")))
+;;   (if true (do (print "1") (print "2")))
 ;;
 ;; The downside here is that you don't get a negative branch, but running
 ;; two things is very common - see for example the "(while)" and "(repeat)"
 ;; macros later in this file.
 ;;
 (defmacro! if2 (fn* (pred one two)
-  `(if ~pred (begin ~one ~two))))
+  `(if ~pred (do ~one ~two))))
 
 
 ;;
@@ -126,7 +126,7 @@
 ;;
 ;;  (when (= 1 1) (print "OK") (print "Still OK") (print "final statement"))
 ;;
-(defmacro! when (fn* (pred &rest) `(if ~pred (begin ~@rest))))
+(defmacro! when (fn* (pred &rest) `(if ~pred (do ~@rest))))
 
 ;;
 ;; Part of our while-implementation.
@@ -176,7 +176,7 @@
 (define apply (lambda (lst:list fun:function)
   (if (nil? lst)
       ()
-      (begin
+      (do
          (fun (car lst))
          (apply (cdr lst) fun)))))
 
@@ -188,7 +188,7 @@
 ;; Return the length of the given string or list.
 (define length (lambda (arg)
   (if (list? arg)
-    (begin
+    (do
       (if (nil? arg) 0
         (inc (length (cdr arg)))))
     0

--- a/test.lisp
+++ b/test.lisp
@@ -26,7 +26,7 @@
 ;;
 (let* (a 5)
   (while (> a 0)
-    (begin
+    (do
      (print "(while) loop - iteration %s" a)
      (set! a (- a 1) true))))
 
@@ -83,7 +83,7 @@
 ;; Test our some of our earlier functions against a range of numbers
 (apply (list -2 -1 0 1 2 3 4 5)
   (lambda (x)
-    (begin
+    (do
       (if (neg? x)  (print "%s is negative" x))
       (if (zero? x) (print "%s is ZERO"     x))
       (if (even? x) (print "%s is EVEN"     x))


### PR DESCRIPTION
This is more standard, and closes #14.