### PR TITLE
Be consistent in defining functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ There are a couple of areas where we've implemented special/unusual things:
 Here's an example of type-checking on a parameter value, in this case a list is required, via the `:list` suffix:
 
 ```lisp
-(define blah (lambda (a:list) (print "I received the list %s" a)))
+(set! blah (fn* (a:list) (print "I received the list %s" a)))
 
 (blah '(1 2 3))    ; => "I received the list (1 2 3)"
 (blah #f)          ; => Error running: argument a to blah was supposed to be list, but got false
@@ -150,7 +150,7 @@ The following type suffixes are permitted and match what you'd expect:
 
 If multiple types are permitted then just keep appending things, for example:
 
-* `(define blah (lambda (a:list:number)  (print "I was given a list OR a number: %s" a)))`
+* `(set! blah (fn* (a:list:number)  (print "I was given a list OR a number: %s" a)))`
   * Allows either a list, or a number.
 
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ That concludes the brief overview, note that `lambda` can be used as a synonym f
 
 ## Features
 
-We have a reasonable number of functions implemented, either in our golang core or in our standard-library (which is implemented in yal itself):
+We have a reasonable number of functions implemented, either in our golang core or in the standard-library which is loaded ahead of all user-scripts (the standard-library is implemented in lisp).
 
 * Basic types include strings, numbers, errors, lists, hashes, etc.
   * `#t` is the true symbol, `#f` is false.
@@ -96,6 +96,7 @@ We have a reasonable number of functions implemented, either in our golang core 
   * `defmacro!` is used to define macros.
   * `fn*` can be used as a synonym for `lambda`.
   * `let*` can be used to define a local scope.
+  * Several functions/macros that are expected to be present can be found in [stdlib/mal.lisp](stdlib/mal.lisp).
 
 Building upon those primitives we have a larger standard-library of functions written in Lisp such as:
 
@@ -107,7 +108,8 @@ Although the lists above should be up to date you can check the definitions to s
   * [builtins/builtins.go](builtins/builtins.go)
 * Primitives implemented in 100% pure lisp:
   * [stdlib/stdlib.lisp](stdlib/stdlib.lisp)
-  * The code in this file is essentially **prepended** to any script that is supplied upon the command-line.
+  * [stdlib/mal.lisp](stdlib/mal.lisp)
+  * The code in these files is essentially **prepended** to any script that is supplied upon the command-line.
 
 
 
@@ -193,6 +195,10 @@ A reasonable amount of sample code can be found in the various included examples
 * [fizzbuzz.lisp](fizzbuzz.lisp) is a standalone sample of solving the fizzbuzz problem.
 * [mtest.lisp](mtest.lisp) shows some macro examples.
 
+As noted there is a standard-library of functions which are loaded along with any user-supplied script.  These functions are implemented in lisp and also serve as a demonstration of syntax and features:
+
+* [stdlib/stdlib.lisp](stdlib/stdlib.lisp)
+* [stdlib/mal.lisp](stdlib/mal.lisp)
 
 
 
@@ -247,11 +253,12 @@ ok  	github.com/skx/yal	2.679s
 
 For longer runs add `-benchtime=30s`, or similar, to the command-line.
 
-Here you see that the lisp version is approximately 3000% slower than the pure golang implementation.  There is a small comparison of my toy scripting languages available here:
+Here you see that the lisp version is approximately 3000% slower than the pure golang implementation.  I put together a small comparison of toy scripting languages available here:
 
 * [Toy Language Benchmarks](https://github.com/skx/toy-language-benchmarks)
 
-This shows that the Lisp implementation here isn't so bad!
+This shows that the Lisp implementation isn't so slow, although it is not the fasted of the scripting languages I've implemented.
+
 
 
 

--- a/args.lisp
+++ b/args.lisp
@@ -1,4 +1,4 @@
-#!/home/skx/go/bin/yal
+#!/usr/bin/env yal
 ;;
 ;;  Usage:
 ;;

--- a/dynamic.lisp
+++ b/dynamic.lisp
@@ -10,8 +10,8 @@
 ;; a given name via `filter`.  Assuming only one response then we're
 ;; able to find it by name, and execute it.
 ;;
-(define call-by-name
-  (lambda (name:string &args)
+(set! call-by-name
+  (fn* (name:string &args)
     (let* (out nil  ; out is the result of the filter
            nm  nil  ; nm is the name of the result == name
            fn  nil) ; fn is the function of the result

--- a/fizzbuzz.lisp
+++ b/fizzbuzz.lisp
@@ -32,10 +32,10 @@
 (define divByThree (lambda (n:number) (zero? (% n 3))))
 
 ;; Is the given number divisible by 5?
-(define divByFive  (lambda (n:number) (zero? (% n 5))))
+(set! divByFive  (fn* (n:number) (zero? (% n 5))))
 
 ;; Run the fizz-buzz test for the given number, N
-(define fizz (lambda (n:number)
+(set! fizz (fn* (n:number)
   (cond
       (and (list (divByThree n) (divByFive n)))  (print "fizzbuzz")
       (divByThree n)                             (print "fizz")

--- a/hash.lisp
+++ b/hash.lisp
@@ -21,7 +21,7 @@
 
 
 ;; This function is used as a callback by apply-hash.
-(define hash-element (lambda (key val)
+(set! hash-element (fn* (key val)
    (print "KEY:%s VAL:%s" key val)))
 
 ;; The `apply-hash` function will trigger a callback for each key and value
@@ -34,7 +34,7 @@
 
 ;; Here we see a type-restriction, the following function can only be
 ;; invoked with a hash-argument.
-(define blah (lambda (h:hash) (print "Got argument of type %s" (type h))))
+(set! blah (fn* (h:hash) (print "Got argument of type %s" (type h))))
 
 ;; Call it
 (blah person)
@@ -55,6 +55,5 @@
 (print "Values in the environment matching the regexp /int/\n%s" out)
 
 ;;
-(apply out (lambda (x) (do
-                        (print "Function in env. matching regexp /int/")
-                        (print "\t%s" (get x :name)))))
+(print "Function in env. matching regexp /int/:")
+(apply out (lambda (x) (print "\t%s" (get x :name))))

--- a/mtest.lisp
+++ b/mtest.lisp
@@ -10,7 +10,7 @@
 
 
 ;; Define a simple list for testing-purposes.
-(define lst (quote (b c)))
+(set! lst (quote (b c)))
 
 ;;
 ;; Here is our first macro, given a variable-name show both the
@@ -105,9 +105,9 @@
 ;;
 ;; Define three variables A, B, & C
 ;;
-(define a 1)
-(define b 2)
-(define c 3)
+(set! a 1)
+(set! b 2)
+(set! c 3)
 
 ;;
 ;; Confirm they have expected values

--- a/stdlib/mal.lisp
+++ b/stdlib/mal.lisp
@@ -1,0 +1,154 @@
+;;; mal.lisp - Compatability with MAL, implemented in lisp.
+
+;; This is essentially prepended to any program the user tries to run,
+;; and implements functions that are expected by any MAL implementation.
+;;
+;; More general functions can be found in stdlib.lisp.
+;;
+
+
+;; Traditionally we use `car` and `cdr` for accessing the first and rest
+;; elements of a list.  For readability it might be nice to vary that
+(set! first (fn* (x:list) (car x)))
+(set! rest  (fn* (x:list) (cdr x)))
+
+;; Some simple tests of numbers
+(set! zero? (fn* (n) (= n 0)))
+(set! one?  (fn* (n) (= n 1)))
+(set! even? (fn* (n) (zero? (% n 2))))
+(set! odd?  (fn* (n) (! (even? n))))
+
+;; is the given argument "true", or "false"?
+(def! true?  (fn* (arg) (if (eq #t arg) true false)))
+(def! false? (fn* (arg) (if (eq #f arg) true false)))
+
+
+
+
+;;
+;; if2 is a simple macro which allows you to run two actions if an
+;; (if ..) test succeeds.
+;;
+;; This means you can write:
+;;
+;;   (if2 true (print "1") (print "2"))
+;;
+;; Instead of having to use (do), like so:
+;;
+;;   (if true (do (print "1") (print "2")))
+;;
+;; The downside here is that you don't get a negative branch, but running
+;; two things is very common - see for example the "(while)" and "(repeat)"
+;; macros later in this file.
+;;
+(defmacro! if2 (fn* (pred one two)
+  `(if ~pred (do ~one ~two))))
+
+
+;;
+;; Run an arbitrary series of statements, if the given condition is true.
+;;
+;; This is the more general/useful version of the "if2" macro, given above.
+;;
+;; Sample usage:
+;;
+;;  (when (= 1 1) (print "OK") (print "Still OK") (print "final statement"))
+;;
+(defmacro! when (fn* (pred &rest) `(if ~pred (do ~@rest))))
+
+;;
+;; Part of our while-implementation.
+;; If the specified predicate is true, then run the body.
+;;
+;; NOTE: This recurses, so it will eventually explode the stack.
+;;
+;; NOTE: We use "if2" not "if".
+;;
+(define while-fun (lambda (predicate body)
+  (if2 (predicate)
+    (body)
+    (while-fun predicate body))))
+
+;;
+;; Now a macro to use the while-fun body as part of a while-function
+;;
+;; NOTE: We use "if2" not "if".
+;;
+(defmacro! while (fn* (expression body)
+                     (list 'while-fun
+                           (list 'lambda '() expression)
+                           (list 'lambda '() body))))
+
+
+;;
+;; cond is a useful thing to have.
+;;
+(defmacro! cond (fn* (&xs)
+  (if (> (length xs) 0)
+      (list 'if (first xs)
+            (if (> (length xs) 1)
+                (nth xs 1)
+              (error "An odd number of forms to (cond..)"))
+            (cons 'cond (rest (rest xs)))))))
+
+;; A useful helper to apply a given function to each element of a list.
+(set! apply (fn* (lst:list fun:function)
+  (if (nil? lst)
+      ()
+      (do
+         (fun (car lst))
+         (apply (cdr lst) fun)))))
+
+
+;; Return the length of the given list.
+(set! length (fn* (arg)
+  (if (list? arg)
+    (do
+      (if (nil? arg) 0
+        (inc (length (cdr arg)))))
+    0
+    )))
+
+
+;; Alias to (length)
+(set! count (fn* (arg) (length arg)))
+
+
+;; Find the Nth item of a list
+(set! nth (fn* (lst:list i:number)
+  (if (> i (length lst))
+    (error "Out of bounds on list-length")
+    (if (= 0 i)
+      (car lst)
+        (nth (cdr lst) (- i 1))))))
+
+
+;; Replace a list with the contents of evaluating the given function on
+;; every item of the list
+(set! map (fn* (xs:list f:function)
+  (if (nil? xs)
+     ()
+       (cons (f (car xs)) (map (cdr xs) f)))))
+
+
+;; This is required for our quote/quasiquote/unquote/splice-unquote handling
+;;
+;; Testing is hard, but
+;;
+;; (define lst (quote (b c)))                      ; b c
+;; (print (quasiquote (a lst d)))                  ; (a lst d)
+;; (print (quasiquote (a (unquote lst) d)))        ; (a (b c) d)
+;; (print (quasiquote (a (splice-unquote lst) d))) ; (a b c d)
+;;
+(set! concat (fn* (seq1 seq2)
+  (if (nil? seq1)
+      seq2
+      (cons (car seq1) (concat (cdr seq1) seq2)))))
+
+
+
+;;
+;; Read a file
+;;
+(def! load-file (fn* (f)
+                     (eval (join (list "(do " (slurp f) "\nnil)")))))

--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -15,5 +15,5 @@ var mal string
 // Contents returns the embedded contents of our Lisp standard-library.
 func Contents() []byte {
 
-	return []byte(stdlib + "\n" + mal)
+	return []byte(stdlib + "\n" + mal + "\n")
 }

--- a/stdlib/stdlib.go
+++ b/stdlib/stdlib.go
@@ -7,9 +7,13 @@ import (
 )
 
 //go:embed stdlib.lisp
-var message string
+var stdlib string
+
+//go:embed mal.lisp
+var mal string
 
 // Contents returns the embedded contents of our Lisp standard-library.
 func Contents() []byte {
-	return []byte(message)
+
+	return []byte(stdlib + "\n" + mal)
 }

--- a/stdlib/stdlib_test.go
+++ b/stdlib/stdlib_test.go
@@ -8,16 +8,24 @@ import (
 func TestStdlib(t *testing.T) {
 	x := Contents()
 
-	data, err := os.ReadFile("stdlib.lisp")
+	var core []byte
+	var mal []byte
+	var err error
+
+	core, err = os.ReadFile("stdlib.lisp")
 	if err != nil {
 		t.Fatalf("failed to read: %s", err)
 	}
-	if len(data) != len(x) {
+
+	mal, err = os.ReadFile("mal.lisp")
+	if err != nil {
+		t.Fatalf("failed to read: %s", err)
+	}
+
+	// Add one for the newline we add in the middle.
+	total := len(core) + 1 + len(mal) + 1
+	if total != len(x) {
 		t.Fatalf("stdlib size mismatch")
 	}
-	for i, b := range data {
-		if x[i] != b {
-			t.Fatalf("mismatch of contents at offset %d", i)
-		}
-	}
+
 }

--- a/test.lisp
+++ b/test.lisp
@@ -32,7 +32,7 @@
 
 
 ;; Define a function, `fact`, to calculate factorials.
-(define fact (lambda (n)
+(set! fact (fn* (n)
   (if (<= n 1)
     1
       (* n (fact (- n 1))))))
@@ -41,7 +41,7 @@
 
 
 ;; Return the number of ms a function invokation took.
-(define benchmark (lambda (fn)
+(set! benchmark (fn* (fn)
   (let* (start-ms (ms)
          _ (fn)
          end-ms (ms))
@@ -78,11 +78,11 @@
 
 
 ;; Define another function, and invoke it
-(define sum2 (lambda (n acc) (if (= n 0) acc (sum2 (- n 1) (+ n acc)))))
+(set! sum2 (fn* (n acc) (if (= n 0) acc (sum2 (- n 1) (+ n acc)))))
 (print "Sum of 1-100: %s" (sum2 100 0))
 
 ;; Now create a utility function to square a number
-(define sq (lambda (x) (* x x)))
+(set! sq (fn* (x) (* x x)))
 
 ;; For each item in the range 1-10, print it, and the associated square.
 ;; Awesome!  Much Wow!
@@ -132,7 +132,7 @@
 ;;
 ;; A simple assertion function
 ;;
-(define assert (lambda (result msg)
+(set! assert (fn* (result msg)
   (if result ()
     (print "ASSERT failed - %s" msg))))
 
@@ -172,12 +172,12 @@
 
 
 ;; We have a built-in eval function, which operates upon symbols, or strings.
-(define e "(+ 3 4)")
+(set! e "(+ 3 4)")
 (print "Eval of '%s' resulted in %s" e (eval e))
 (print "Eval of '%s' resulted in %s" "(+ 40 2)" (eval "(+ 40 2)"))
 
 ;; Simple test of `cond`
-(define a 6)
+(set! a 6)
 (cond
     (> a 20) (print "A > 20")
     (> a 15) (print "A > 15")
@@ -195,5 +195,5 @@
 (print "%s" (lower "Hello, World; in LOWER-case."))
 
 ;; All done! -> In red :)
-(define red (lambda (msg) (sprintf "\e[0;31m%s\e[0m" msg)))
+(set! red (fn* (msg) (sprintf "\e[0;31m%s\e[0m" msg)))
 (print (red "All done!"))


### PR DESCRIPTION
I've come up with the rule:

* Use "`(def! xx (fn*))`" for all functions.
* UNLESS they're being used with apply, map, repeat, while, etc.
  * In that case we're going to use lambda, since that's what they are.

That might feel a little arbitrary but:

* It is 100% consistent.
* It allows us to demonstrate both approaches.

This closes #15.