### PR TITLE
25 help

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ We have a reasonable number of functions implemented, either in our golang core 
   * Hashes are literals like this `{ :name "Steve" :location "Helsinki" }`
   * Hash functions are `contains?`, `get`, `keys`, `set`, & `vals`.
     * Note that keys are returned in sorted order.  Values are returned in order of their sorted keys too.
+* Help functions:
+  * `help` will return the supplied help text for any functions which provide it - which includes all of our built-in functions and large parts of our standard-library.
+  * **NOTE**: This does not (yet?) include help for special forms such as `(let* ..)`, `(if ..)`, etc.
 * List operations:
   * `car`, `cdr`, `cons`, `first`, `last`, `list`, & `sort`.
 * Logical operations:

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ There are a couple of areas where we've implemented special/unusual things:
   * See [args.lisp](args.lisp) for an example.
 * Introspection via the `(env)` function, which will return details of all variables/functions in the environment.
   * Allowing dynamic invocation shown in [dynamic.lisp](dynamic.lisp) and other neat things.
+  * This includes help-information for both built-in and user-written functions.
 * Support for hashes as well as lists/strings/numbers/etc.
   * A hash looks like this `{ :name "Steve" :location "Helsinki" }`
   * Sample code is visible in [hash.lisp](hash.lisp).
@@ -188,6 +189,13 @@ Once you've built, and optinall installed, the CLI driver there are two ways to 
   * `yal -e "(print (os))"`
 * By passing the name of a file to read and execute.
   * `yal test.lisp`
+
+As our interpreter allows documentation to be attached to functions, both those implemented in golang and those written in lisp, we also have a flag to dump that information:
+
+* `yal -h`
+  * Shows all functions which contain help-text, in sorted order.
+  * Examples are included where available.
+
 
 
 

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -90,13 +90,11 @@ Example:  (type "string") (type 3) (type type)`})
 	// core
 	env.Set("arch", &primitive.Procedure{F: archFn, Help: `arch returns a simple string describing the architecture the current host is running upon.
 
-\tSee also: (arch)
-\t Example:  (print (arch))
-`})
+\tSee also: (os)
+\t Example: (print (arch))`})
 	env.Set("date", &primitive.Procedure{F: dateFn, Help: `date returns a list containing date-related fields; the day of the week, the day-number, the month-number, and the year.
 
-\tSee also: (date)
-`})
+\tSee also: (time)`})
 	env.Set("error", &primitive.Procedure{F: errorFn})
 	env.Set("getenv", &primitive.Procedure{F: getenvFn})
 	env.Set("ms", &primitive.Procedure{F: msFn})
@@ -104,8 +102,7 @@ Example:  (type "string") (type 3) (type type)`})
 	env.Set("os", &primitive.Procedure{F: osFn, Help: `os returns a simple string describing the operating system the current host is running.
 
 \tSee also: (arch)
-\t Example: (print (os))
-`,
+\t Example: (print (os))`,
 	})
 	env.Set("print", &primitive.Procedure{F: printFn})
 	env.Set("sort", &primitive.Procedure{F: sortFn})
@@ -113,8 +110,7 @@ Example:  (type "string") (type 3) (type type)`})
 	env.Set("slurp", &primitive.Procedure{F: slurpFn})
 	env.Set("time", &primitive.Procedure{F: timeFn, Help: `time returns a list containing time-related entries; the current hour, the current minute past the hour, and the current value of the seconds.
 
-\tSee also: (date)
-`})
+\tSee also: (date)`})
 
 	// string
 	env.Set("chr", &primitive.Procedure{F: chrFn})

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -62,10 +62,13 @@ func PopulateEnvironment(env *env.Environment) {
 	// We only actually need to implement "<" in Golang, the rest
 	// can be added in lisp.
 	env.Set("<", &primitive.Procedure{F: ltFn})
+	env.Set("=", &primitive.Procedure{F: equalsFn, Help: `= returns true if supplied with two numerical values, of equal value.
+\tSee also: eq
+\t Example: (print (= 3 a))`})
+	env.Set("eq", &primitive.Procedure{F: eqFn, Help: `eq returns true if the two values supplied as parameters have the same type, and string representation.
 
-	// equality
-	env.Set("=", &primitive.Procedure{F: equalsFn})
-	env.Set("eq", &primitive.Procedure{F: eqFn})
+\tSee also: =
+\t Example: (print (eq "bob" 2))`})
 
 	// Types
 	env.Set("nil?", &primitive.Procedure{F: nilFn, Help: `nil? returns a true value if the specified argument is nil, or an empty list.`})
@@ -81,11 +84,25 @@ Example:  (type "string") (type 3) (type type)`})
 	env.Set("list", &primitive.Procedure{F: listFn, Help: `list creates and returns a list containing each of the specified arguments, in order.`})
 
 	// Hash
-	env.Set("contains?", &primitive.Procedure{F: containsFn})
-	env.Set("get", &primitive.Procedure{F: getFn})
-	env.Set("keys", &primitive.Procedure{F: keysFn})
-	env.Set("set", &primitive.Procedure{F: setFn})
-	env.Set("vals", &primitive.Procedure{F: valsFn})
+	env.Set("contains?", &primitive.Procedure{F: containsFn, Help: `contains? returns true if the hash specified as the first argument contains the key specified as the second argument.`})
+	env.Set("get", &primitive.Procedure{F: getFn, Help: `get returns the specified field from the specified hash.
+
+\tSee also: set
+\t Example: (get {:name "steve" :location "Europe" } ":name")`})
+	env.Set("keys", &primitive.Procedure{F: keysFn, Help: `keys returns the keys which are present in the specified hash.
+
+NOTE: Keys are returned in sorted order.
+
+\tSee also: vals`})
+	env.Set("set", &primitive.Procedure{F: setFn, Help: `set updates the specified hash, setting the value given by name.
+
+\t: See also: get
+\t: Example:  (set! person {:name "Steve"})  (set person :name "Bobby")`})
+	env.Set("vals", &primitive.Procedure{F: valsFn, Help: `valus returns the values which are present in the specified hash.
+
+NOTE: Values are returned in the order of their sorted keys.
+
+\tSee also: keys`})
 
 	// core
 	env.Set("arch", &primitive.Procedure{F: archFn, Help: `arch returns a simple string describing the architecture the current host is running upon.
@@ -95,29 +112,64 @@ Example:  (type "string") (type 3) (type type)`})
 	env.Set("date", &primitive.Procedure{F: dateFn, Help: `date returns a list containing date-related fields; the day of the week, the day-number, the month-number, and the year.
 
 \tSee also: (time)`})
-	env.Set("error", &primitive.Procedure{F: errorFn})
-	env.Set("getenv", &primitive.Procedure{F: getenvFn})
-	env.Set("ms", &primitive.Procedure{F: msFn})
-	env.Set("now", &primitive.Procedure{F: nowFn})
+	env.Set("error", &primitive.Procedure{F: errorFn, Help: `error raises an error with the specified argument as the explaination.
+
+\t Example: (error "Expected foo to be bar!")`})
+	env.Set("getenv", &primitive.Procedure{F: getenvFn, Help: `getenv returns the contents of the environmental-variable which was specified as the first argument.
+
+\t Example: (print (getenv "HOME"))`})
+	env.Set("ms", &primitive.Procedure{F: msFn, Help: `ms returns the current time as a number of milliseconds, it is useful for benchmarking.
+
+\tSee also: now`})
+	env.Set("now", &primitive.Procedure{F: nowFn, Help: `now returns the number of seconds since the Unix Epoch.
+
+\tSee also: ms`})
 	env.Set("os", &primitive.Procedure{F: osFn, Help: `os returns a simple string describing the operating system the current host is running.
 
 \tSee also: (arch)
 \t Example: (print (os))`,
 	})
-	env.Set("print", &primitive.Procedure{F: printFn})
-	env.Set("sort", &primitive.Procedure{F: sortFn})
-	env.Set("sprintf", &primitive.Procedure{F: sprintfFn})
-	env.Set("slurp", &primitive.Procedure{F: slurpFn})
+	env.Set("print", &primitive.Procedure{F: printFn, Help: `print is used to output text to the console.  It can be called with either an object/string to print, or a format-string and list of parameters.
+
+\tSee also: sprintf
+\t Example: (print "Hello, world")
+\t Example: (print "Hello user %s you are %d" (getenv "USER") 32)`})
+	env.Set("sort", &primitive.Procedure{F: sortFn, Help: `sort will sort the items in the list specified as the single argument, and return them as a new list.
+
+\t Example: (print (sort 3 43  1 "Steve" "Adam"))
+`})
+	env.Set("sprintf", &primitive.Procedure{F: sprintfFn, Help: `sprintf allows formating values with a simple format-string.
+
+\tSee also: print
+\t Example: (sprintf "Today is %s" (weekday))`})
+	env.Set("slurp", &primitive.Procedure{F: slurpFn, Help: `slurp returns the contents of the specified file.`})
 	env.Set("time", &primitive.Procedure{F: timeFn, Help: `time returns a list containing time-related entries; the current hour, the current minute past the hour, and the current value of the seconds.
 
 \tSee also: (date)`})
 
 	// string
-	env.Set("chr", &primitive.Procedure{F: chrFn})
-	env.Set("match", &primitive.Procedure{F: matchFn})
-	env.Set("ord", &primitive.Procedure{F: ordFn})
-	env.Set("split", &primitive.Procedure{F: splitFn})
-	env.Set("str", &primitive.Procedure{F: strFn})
+	env.Set("chr", &primitive.Procedure{F: chrFn, Help: `chr returns a string containing the single character who's ASCII code was provided.
+
+\tSee also: ord
+\t Example: (chr 42) ; => "*"`})
+
+	env.Set("match", &primitive.Procedure{F: matchFn, Help: `match is used to perform regular expression matches.  The first parameter must be a suitable regular expression, supplied in string-form, and the second should be a value to test against.  If the second value is not a string it will be stringified prior to the test-attempt.
+
+Any matches found will be returned as a list, with nil being returned on no match.
+
+\t Example: (print (match "c.ke$" "cake"))`})
+	env.Set("ord", &primitive.Procedure{F: ordFn, Help: `ord returns the ASCII code for the character provided as the first input.
+
+\tSee also: chr
+\t Example: (ord "a") ; => 97`})
+
+	env.Set("split", &primitive.Procedure{F: splitFn, Help: `split accepts two string parameters, and splits the first string by the term specified as the second argument, returning a list of the results.
+
+\tSee also: join
+\t Example: (split "steve" "e") ; => ("st" "v")
+\t Example: (split "steve" "")  ; => ("s" "t" "e" "v" "e")`})
+
+	env.Set("str", &primitive.Procedure{F: strFn, Help: `str converts the parameter supplied to a string, and returns it.`})
 }
 
 // Convert a string such as "steve\tkemp" into "steve<TAB>kemp"

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -89,6 +89,11 @@ Example:  (type "string") (type 3) (type type)`})
 
 \tSee also: set
 \t Example: (get {:name "steve" :location "Europe" } ":name")`})
+
+	env.Set("help", &primitive.Procedure{F: helpFn, Help: `help returns any help associated with the item specified as the single argument.
+
+\tExample: (print (help print))`})
+
 	env.Set("keys", &primitive.Procedure{F: keysFn, Help: `keys returns the keys which are present in the specified hash.
 
 NOTE: Keys are returned in sorted order.
@@ -752,6 +757,23 @@ func getFn(args []primitive.Primitive) primitive.Primitive {
 
 	tmp := args[0].(primitive.Hash)
 	return tmp.Get(args[1].ToString())
+}
+
+// helpFn is the implementation of `(help fn)`
+func helpFn(args []primitive.Primitive) primitive.Primitive {
+	// We need a single argument
+	if len(args) != 1 {
+		return primitive.Error("invalid argument count")
+	}
+
+	// Which is a function
+	proc, ok := args[0].(*primitive.Procedure)
+
+	if !ok {
+		return primitive.Error("argument not a procedure")
+	}
+
+	return primitive.String(proc.Help)
 }
 
 // keysFn is the implementation of `(keys hash)`

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -68,15 +68,17 @@ func PopulateEnvironment(env *env.Environment) {
 	env.Set("eq", &primitive.Procedure{F: eqFn})
 
 	// Types
-	env.Set("nil?", &primitive.Procedure{F: nilFn})
-	env.Set("type", &primitive.Procedure{F: typeFn})
+	env.Set("nil?", &primitive.Procedure{F: nilFn, Help: `nil? returns a true value if the specified argument is nil, or an empty list.`})
+	env.Set("type", &primitive.Procedure{F: typeFn, Help: `type returns a string describing the type of the specified object.
+
+Example:  (type "string") (type 3) (type type)`})
 
 	// List
-	env.Set("car", &primitive.Procedure{F: carFn})
-	env.Set("cdr", &primitive.Procedure{F: cdrFn})
-	env.Set("cons", &primitive.Procedure{F: consFn})
-	env.Set("join", &primitive.Procedure{F: joinFn})
-	env.Set("list", &primitive.Procedure{F: listFn})
+	env.Set("car", &primitive.Procedure{F: carFn, Help: `car returns the first item from the specified list.`})
+	env.Set("cdr", &primitive.Procedure{F: cdrFn, Help: `cdr returns all items from the specified list, except the first.`})
+	env.Set("cons", &primitive.Procedure{F: consFn, Help: `cons joins the two specified lists: FIXME`})
+	env.Set("join", &primitive.Procedure{F: joinFn, Help: `join returns a string formed by converting every element of the supplied list into a string and concatenating them.`})
+	env.Set("list", &primitive.Procedure{F: listFn, Help: `list creates and returns a list containing each of the specified arguments, in order.`})
 
 	// Hash
 	env.Set("contains?", &primitive.Procedure{F: containsFn})
@@ -590,7 +592,6 @@ func splitFn(args []primitive.Primitive) primitive.Primitive {
 	return c
 }
 
-
 // timeFn returns the current (HH, MM, SS) as a list.
 func timeFn(args []primitive.Primitive) primitive.Primitive {
 	var ret primitive.List
@@ -607,7 +608,6 @@ func timeFn(args []primitive.Primitive) primitive.Primitive {
 
 	return ret
 }
-
 
 // (join (1 2 3)
 func joinFn(args []primitive.Primitive) primitive.Primitive {

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -88,18 +88,33 @@ Example:  (type "string") (type 3) (type type)`})
 	env.Set("vals", &primitive.Procedure{F: valsFn})
 
 	// core
-	env.Set("arch", &primitive.Procedure{F: archFn})
-	env.Set("date", &primitive.Procedure{F: dateFn})
+	env.Set("arch", &primitive.Procedure{F: archFn, Help: `arch returns a simple string describing the architecture the current host is running upon.
+
+\tSee also: (arch)
+\t Example:  (print (arch))
+`})
+	env.Set("date", &primitive.Procedure{F: dateFn, Help: `date returns a list containing date-related fields; the day of the week, the day-number, the month-number, and the year.
+
+\tSee also: (date)
+`})
 	env.Set("error", &primitive.Procedure{F: errorFn})
 	env.Set("getenv", &primitive.Procedure{F: getenvFn})
 	env.Set("ms", &primitive.Procedure{F: msFn})
 	env.Set("now", &primitive.Procedure{F: nowFn})
-	env.Set("os", &primitive.Procedure{F: osFn})
+	env.Set("os", &primitive.Procedure{F: osFn, Help: `os returns a simple string describing the operating system the current host is running.
+
+\tSee also: (arch)
+\t Example: (print (os))
+`,
+	})
 	env.Set("print", &primitive.Procedure{F: printFn})
 	env.Set("sort", &primitive.Procedure{F: sortFn})
 	env.Set("sprintf", &primitive.Procedure{F: sprintfFn})
 	env.Set("slurp", &primitive.Procedure{F: slurpFn})
-	env.Set("time", &primitive.Procedure{F: timeFn})
+	env.Set("time", &primitive.Procedure{F: timeFn, Help: `time returns a list containing time-related entries; the current hour, the current minute past the hour, and the current value of the seconds.
+
+\tSee also: (date)
+`})
 
 	// string
 	env.Set("chr", &primitive.Procedure{F: chrFn})

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -773,7 +773,20 @@ func helpFn(args []primitive.Primitive) primitive.Primitive {
 		return primitive.Error("argument not a procedure")
 	}
 
-	return primitive.String(proc.Help)
+	// Return value
+	str := ""
+
+	for _, arg := range proc.Args {
+		if len(str) == 0 {
+			str = "Arguments"
+		}
+		str += " " + arg.ToString()
+	}
+	if len(str) > 0 {
+		str += "\n"
+	}
+	str += proc.Help
+	return primitive.String(str)
 }
 
 // keysFn is the implementation of `(keys hash)`

--- a/builtins/builtins_test.go
+++ b/builtins/builtins_test.go
@@ -12,6 +12,36 @@ import (
 	"github.com/skx/yal/primitive"
 )
 
+// TestHelp ensures that all our built-in functions have help-text available
+func TestHelp(t *testing.T) {
+
+	// create a new environment, and populate it
+	e := env.New()
+	PopulateEnvironment(e)
+
+	// For each function
+	items := e.Items()
+
+	for name, val := range items {
+
+		proc, ok := val.(*primitive.Procedure)
+		if ok {
+
+			t.Run("Testing "+name, func(t *testing.T) {
+
+				// We ignore one-character long names.
+				if len(name) == 1 {
+					t.Skip("Ignoring built-in function for the moment")
+				}
+
+				if len(proc.Help) == 0 {
+					t.Fatalf("help text is unset")
+				}
+			})
+		}
+	}
+}
+
 // TestSetup just instantiates the primitives in the environment
 func TestSetup(t *testing.T) {
 
@@ -1416,7 +1446,7 @@ func TestDateTime(t *testing.T) {
 	}
 
 	// "weekday", "day", "month", "year" == four entries
-	if len(out)!= 4 {
+	if len(out) != 4 {
 		t.Fatalf("date list had the wrong length, got %d: %v", len(out), out)
 	}
 
@@ -1427,7 +1457,7 @@ func TestDateTime(t *testing.T) {
 	}
 
 	// "hour", "minute", "seconds" == three entries
-	if len(out)!= 3 {
+	if len(out) != 3 {
 		t.Fatalf("time list had the wrong length, got %d: %v", len(out), out)
 	}
 

--- a/builtins/builtins_test.go
+++ b/builtins/builtins_test.go
@@ -12,8 +12,9 @@ import (
 	"github.com/skx/yal/primitive"
 )
 
-// TestHelp ensures that all our built-in functions have help-text available
-func TestHelp(t *testing.T) {
+// TestEnsureHelpPresent ensures that all our built-in functions have
+// help-text available
+func TestEnsureHelpPresent(t *testing.T) {
 
 	// create a new environment, and populate it
 	e := env.New()
@@ -1645,6 +1646,58 @@ func TestContains(t *testing.T) {
 	}
 	if v != primitive.Bool(false) {
 		t.Fatalf("unexpectedly found missing key")
+	}
+}
+
+func TestHelp(t *testing.T) {
+	// no arguments
+	out := helpFn([]primitive.Primitive{})
+
+	// Will lead to an error
+	e, ok := out.(primitive.Error)
+	if !ok {
+		t.Fatalf("expected error, got %v", out)
+	}
+	if !strings.Contains(string(e), "argument") {
+		t.Fatalf("got error, but wrong one")
+	}
+
+	// First argument must be a procedure
+	out = helpFn([]primitive.Primitive{
+		primitive.String("foo"),
+	})
+
+	// Will lead to an error
+	e, ok = out.(primitive.Error)
+	if !ok {
+		t.Fatalf("expected error, got %v", out)
+	}
+	if !strings.Contains(string(e), "not a procedure") {
+		t.Fatalf("got error, but wrong one %v", out)
+	}
+
+	//
+	// create a new environment, and populate it
+	//
+	env := env.New()
+	PopulateEnvironment(env)
+
+	for _, name := range []string{"print", "sprintf"} {
+
+		fn, ok := env.Get(name)
+		if !ok {
+			t.Fatalf("failed to lookup function %s in environment", name)
+		}
+
+		result := helpFn([]primitive.Primitive{fn.(*primitive.Procedure)})
+
+		txt, ok2 := result.(primitive.String)
+		if !ok2 {
+			t.Fatalf("expected a string, got %v", result)
+		}
+		if !strings.Contains(txt.ToString(), "print") {
+			t.Fatalf("got help text, but didn't find expected content: %v", result)
+		}
 	}
 }
 

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -897,7 +897,7 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 			case primitive.Symbol("lambda"), primitive.Symbol("fn*"):
 
 				// ensure we have arguments
-				if len(listExp) < 3 {
+				if len(listExp) != 3 && len(listExp) != 4 {
 					return primitive.Error("wrong number of arguments")
 				}
 
@@ -918,6 +918,15 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 					args = append(args, xs)
 				}
 
+				body := listExp[2]
+				help := ""
+
+				// If there's an optional help string ..
+				if len(listExp) == 4 {
+					help = listExp[2].ToString()
+					body = listExp[3]
+
+				}
 				// This is a procedure, which will default
 				// to not being a macro.
 				//
@@ -925,8 +934,9 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 				// "(defmacro!..)"
 				return &primitive.Procedure{
 					Args:  args,
-					Body:  listExp[2],
+					Body:  body,
 					Env:   e,
+					Help:  help,
 					Macro: false,
 				}
 

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -804,6 +804,13 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 					tmp.Set(":name", primitive.String(key))
 					tmp.Set(":value", v)
 
+					// Is this a procedure?  If so
+					// add the help-text
+					proc, ok := v.(*primitive.Procedure)
+					if ok {
+						tmp.Set(":help", primitive.String(proc.Help))
+					}
+
 					c = append(c, tmp)
 				}
 

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -808,7 +808,9 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 					// add the help-text
 					proc, ok := v.(*primitive.Procedure)
 					if ok {
-						tmp.Set(":help", primitive.String(proc.Help))
+						if len(proc.Help) > 0 {
+							tmp.Set(":help", primitive.String(proc.Help))
+						}
 					}
 
 					c = append(c, tmp)

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -50,8 +50,51 @@ func TestTimeout(t *testing.T) {
 	// We should get the context error, but sometimes we don't
 	// the important thing is we DON'T hang forever
 	if !strings.Contains(out.ToString(), "deadline exceeded") &&
-		!strings.Contains(out.ToString(), "not a function")		{
+		!strings.Contains(out.ToString(), "not a function") {
 		t.Fatalf("Didn't get the expected output.  Got: %s", out.ToString())
+	}
+
+}
+
+// TestStdlibHelp is designed to ensure that > 80% of our standard library
+// functions have help-documentation
+func TestStdlibHelp(t *testing.T) {
+
+	// Load our standard library
+	st := stdlib.Contents()
+	std := string(st)
+
+	// Create a new interpreter
+	l := New(std)
+
+	// With a new environment
+	env := env.New()
+
+	// Populate the default primitives
+	builtins.PopulateEnvironment(env)
+
+	// Run it
+	_ = l.Evaluate(env)
+
+	// Now we should have an environment which is
+	// populated with functions
+	for name, val := range env.Items() {
+
+		proc, ok := val.(*primitive.Procedure)
+
+		if !ok {
+			t.Skip("ignoring non-procedure entry in environment " + name)
+		}
+		if len(name) == 1 {
+			t.Skip("ignoring procedure with a single-character name " + name)
+		}
+
+		t.Run(name, func(t *testing.T) {
+
+			if len(proc.Help) == 0 {
+				t.Fatalf("empty help for %s", name)
+			}
+		})
 	}
 
 }

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/skx/yal/builtins"
 	"github.com/skx/yal/env"
@@ -23,10 +24,11 @@ func main() {
 
 	// Look to see if we're gonna execute a statement
 	exp := flag.String("e", "", "A string to evaluate.")
+	hlp := flag.Bool("h", false, "Should we show help information, and exit?")
 	flag.Parse()
 
 	// Ensure we have an argument
-	if len (flag.Args()) < 1 && ( *exp == "" ) {
+	if len(flag.Args()) < 1 && (*exp == "") && !*hlp {
 		fmt.Printf("Usage: yal [-e expr] file.lisp\n")
 		return
 	}
@@ -39,7 +41,7 @@ func main() {
 	}
 
 	// If we have a file, then read the content
-	if (len(flag.Args() ) > 0) {
+	if len(flag.Args()) > 0 {
 		content, err := os.ReadFile(flag.Args()[0])
 		if err != nil {
 			fmt.Printf("Error reading %s:%s\n", os.Args[1], err)
@@ -68,6 +70,34 @@ func main() {
 
 	// Populate the default primitives
 	builtins.PopulateEnvironment(environment)
+
+	// Show the help?
+	if *hlp {
+
+		// Build up a list of all things known in the environment
+		keys := []string{}
+
+		items := environment.Items()
+		for k := range items {
+			keys = append(keys, k)
+		}
+
+		// sort the items
+		sort.Strings(keys)
+
+		for _, key := range keys {
+
+			val, _ := environment.Get(key)
+
+			prc, ok := val.(*primitive.Procedure)
+			if ok && len(prc.Help) > 0 {
+				fmt.Printf("%s\n\t%s\n\n", key, prc.Help)
+			}
+
+		}
+
+		return
+	}
 
 	// Read the standard library
 	pre := stdlib.Contents()

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/skx/yal/builtins"
 	"github.com/skx/yal/env"
@@ -74,6 +75,16 @@ func main() {
 	// Show the help?
 	if *hlp {
 
+		// Read the standard library
+		pre := stdlib.Contents()
+
+		// Create a new interpreter with that source
+		interpreter := eval.New(string(pre))
+
+		// Now evaluate the library, so we get the help for the
+		// built-in functions
+		interpreter.Evaluate(environment)
+
 		// Build up a list of all things known in the environment
 		keys := []string{}
 
@@ -91,7 +102,9 @@ func main() {
 
 			prc, ok := val.(*primitive.Procedure)
 			if ok && len(prc.Help) > 0 {
-				fmt.Printf("%s\n\t%s\n\n", key, prc.Help)
+				txt := prc.Help
+				txt = strings.Replace(txt, "\\t", "\t", -1)
+				fmt.Printf("%s\n\t%s\n\n", key, txt)
 			}
 
 		}

--- a/primitive/procedure.go
+++ b/primitive/procedure.go
@@ -20,6 +20,10 @@ type Procedure struct {
 	// if it is a native one.
 	F func(args []Primitive) Primitive
 
+	// Help contains some function-specific help text, ideally with
+	// an example usage of the function.
+	Help string
+
 	// Macro is true is this function should have arguments passed literally, and
 	// not evaluated.
 	Macro bool

--- a/stdlib/mal.lisp
+++ b/stdlib/mal.lisp
@@ -53,7 +53,9 @@
 ;;
 ;;  (when (= 1 1) (print "OK") (print "Still OK") (print "final statement"))
 ;;
-(defmacro! when (fn* (pred &rest) `(if ~pred (do ~@rest))))
+(defmacro! when (fn* (pred &rest)
+                     "when is a macro which runs the specified body, providing the specified predicate is true.    It is similar to an if-statement, however there is no provision for an 'else' clause, and the body specified may contain more than once expression to be evaluated."
+                     `(if ~pred (do ~@rest))))
 
 ;;
 ;; If the specified predicate is true, then run the body.
@@ -61,25 +63,27 @@
 ;; NOTE: This recurses, so it will eventually explode the stack.
 ;;
 (defmacro! while (fn* (condition &body)
-  (let* (inner-sym (gensym))
-    `(let* (~inner-sym (fn* ()
-                            (if ~condition
-                                (do
-                                    ~@body
-                                    (~inner-sym)))))
-       (~inner-sym)))))
+                      "while is a macro which repeatedly runs the specified body, while the condition returns a true-result"
+                      (let* (inner-sym (gensym))
+                        `(let* (~inner-sym (fn* ()
+                                                (if ~condition
+                                                    (do
+                                                        ~@body
+                                                        (~inner-sym)))))
+                           (~inner-sym)))))
 
 
 ;;
 ;; cond is a useful thing to have.
 ;;
 (defmacro! cond (fn* (&xs)
-  (if (> (length xs) 0)
-      (list 'if (first xs)
-            (if (> (length xs) 1)
-                (nth xs 1)
-              (error "An odd number of forms to (cond..)"))
-            (cons 'cond (rest (rest xs)))))))
+                     "cond is a macro which accepts a list of conditions and results, and returns the value of the first matching condition.  It is similar in functionality to a C case-statement."
+                     (if (> (length xs) 0)
+                         (list 'if (first xs)
+                               (if (> (length xs) 1)
+                                   (nth xs 1)
+                                 (error "An odd number of forms to (cond..)"))
+                               (cons 'cond (rest (rest xs)))))))
 
 ;; A useful helper to apply a given function to each element of a list.
 (set! apply (fn* (lst:list fun:function)

--- a/stdlib/mal.lisp
+++ b/stdlib/mal.lisp
@@ -9,18 +9,39 @@
 
 ;; Traditionally we use `car` and `cdr` for accessing the first and rest
 ;; elements of a list.  For readability it might be nice to vary that
-(set! first (fn* (x:list) (car x)))
-(set! rest  (fn* (x:list) (cdr x)))
+(set! first (fn* (x:list)
+                 "Return the first element of the specified list.  This is an alias for 'car'."
+                 (car x)))
+
+(set! rest (fn* (x:list)
+                 "Return all elements of the specified list, except the first.  This is an alias for 'cdr'."
+                 (cdr x)))
 
 ;; Some simple tests of numbers
-(set! zero? (fn* (n) (= n 0)))
-(set! one?  (fn* (n) (= n 1)))
-(set! even? (fn* (n) (zero? (% n 2))))
-(set! odd?  (fn* (n) (! (even? n))))
+(set! zero? (fn* (n)
+                 "Return true if the number supplied as the first argument to this function is equal to zero."
+                 (= n 0)))
+
+(set! one? (fn* (n)
+                "Return true if the number supplied as the argument to this function is equal to one."
+                (= n 1)))
+
+(set! even? (fn* (n)
+                 "Return true if the number supplied as the argument to this function is even."
+                 (zero? (% n 2))))
+
+(set! odd?  (fn* (n)
+                 "Return true if the number supplied as the argument to this function is odd."
+                 (! (even? n))))
 
 ;; is the given argument "true", or "false"?
-(def! true?  (fn* (arg) (if (eq #t arg) true false)))
-(def! false? (fn* (arg) (if (eq #f arg) true false)))
+(def! true?  (fn* (arg)
+                  "Return true if the argument supplied to this function is true."
+                  (if (eq #t arg) true false)))
+
+(def! false? (fn* (arg)
+                  "Return true if the argument supplied to this function is false."
+                  (if (eq #f arg) true false)))
 
 
 ;; Run an arbitrary series of statements, if the given condition is true.
@@ -71,33 +92,38 @@
 
 ;; Return the length of the given list.
 (set! length (fn* (arg)
-  (if (list? arg)
-    (do
-      (if (nil? arg) 0
-        (inc (length (cdr arg)))))
-    0
-    )))
+                  "Return the length of the supplied list.  See-also strlen."
+                  (if (list? arg)
+                      (do
+                          (if (nil? arg) 0
+                            (inc (length (cdr arg)))))
+                    0
+                    )))
 
 
 ;; Alias to (length)
-(set! count (fn* (arg) (length arg)))
+(set! count (fn* (arg)
+                 "Return the length of the supplied list. This is an alias for (length)."
+                 (length arg)))
 
 
 ;; Find the Nth item of a list
 (set! nth (fn* (lst:list i:number)
-  (if (> i (length lst))
-    (error "Out of bounds on list-length")
-    (if (= 0 i)
-      (car lst)
-        (nth (cdr lst) (- i 1))))))
+               "Return the Nth item of the specified list.
+
+Note that offset starts from 0, rather than 1, for the first item."
+               (if (> i (length lst))
+                   (error "Out of bounds on list-length")
+                 (if (= 0 i)
+                     (car lst)
+                   (nth (cdr lst) (- i 1))))))
 
 
-;; Replace a list with the contents of evaluating the given function on
-;; every item of the list
 (set! map (fn* (xs:list f:function)
-  (if (nil? xs)
-     ()
-       (cons (f (car xs)) (map (cdr xs) f)))))
+               "Return a list with the contents of evaluating the given function on every item of the supplied list."
+               (if (nil? xs)
+                   ()
+                 (cons (f (car xs)) (map (cdr xs) f)))))
 
 
 ;; This is required for our quote/quasiquote/unquote/splice-unquote handling
@@ -119,5 +145,6 @@
 ;;
 ;; Read a file
 ;;
-(def! load-file (fn* (f)
-                     (eval (join (list "(do " (slurp f) "\nnil)")))))
+(def! load-file (fn* (filename)
+                     "Load and execute the contents of the supplied filename."
+                     (eval (join (list "(do " (slurp filename) "\nnil)")))))

--- a/stdlib/stdlib.lisp
+++ b/stdlib/stdlib.lisp
@@ -26,7 +26,7 @@
                        (eq (type x) "procedure(golang)")))))
 
 (set! hash?     (fn* (x)
-                     "Returns true if the argument specified is a hash"
+                     "Returns true if the argument specified is a hash."
                      (eq (type x) "hash")))
 
 (set! macro?    (fn* (x)

--- a/stdlib/stdlib.lisp
+++ b/stdlib/stdlib.lisp
@@ -131,12 +131,22 @@
 
 
 ;; inc/dec are useful primitives to have
-(set! inc (fn* (n:number) (+ n 1)))
-(set! dec (fn* (n:number) (- n 1)))
+(set! inc (fn* (n:number)
+               "inc will add one to the supplied value, and return the result."
+               (+ n 1)))
+
+(set! dec (fn* (n:number)
+               "dec will subtract one from the supplied value, and return the result."
+               (- n 1)))
 
 ;; We could also define the incr/decr operations as macros.
-(defmacro! incr (fn* (x) `(set! ~x (+ ~x 1))))
-(defmacro! decr (fn* (x) `(set! ~x (- ~x 1))))
+(defmacro! incr (fn* (x)
+                     "incr is a macro which will return the given value, incremented by one."
+                     `(set! ~x (+ ~x 1))))
+
+(defmacro! decr (fn* (x)
+                     "decr is a macro which will return the given value, decremented by one."
+                     `(set! ~x (- ~x 1))))
 
 ;; Not is useful
 (set! !     (fn* (x) (if x #f #t)))

--- a/stdlib/stdlib.lisp
+++ b/stdlib/stdlib.lisp
@@ -66,15 +66,38 @@
 ;;
 ;; create some helper functions for retrieving the various parts of
 ;; the date/time.
-(set! year (fn* () (nth (date) 3)))
-(set! month (fn* () (nth (date) 2)))
-(set! day (fn* () (nth (date) 1)))
-(set! weekday (fn* () (nth (date) 0)))
+(set! year (fn* ()
+                "Return the current year, as an integer."
+                (nth (date) 3)))
 
-(set! hour (fn* () (nth (time) 0)))
-(set! minute (fn* () (nth (time) 1)))
-(set! second (fn* () (nth (time) 2)))
-(set! hms (fn* () (sprintf "%s:%s:%s" (hour) (minute) (second))))
+(set! month (fn* ()
+                 "Return the number of the current month, as an integer."
+                 (nth (date) 2)))
+
+(set! day (fn* ()
+               "Return the day of the current month, as an integer."
+               (nth (date) 1)))
+
+(set! weekday (fn* ()
+                   "Return a string containing the current day of the week."
+                   (nth (date) 0)))
+
+(set! hour (fn* ()
+                "Return the current hour, as an integer."
+                (nth (time) 0)))
+
+(set! minute (fn* ()
+                  "Return the current minute, as an integer."
+                  (nth (time) 1)))
+
+(set! second (fn* ()
+                  "Return the current seconds, as an integer."
+                  (nth (time) 2)))
+
+(set! hms (fn* ()
+               "Return the current time, formatted as 'HH:MM:SS', as a string."
+               (sprintf "%s:%s:%s" (hour) (minute) (second))))
+
 
 ;;
 ;; This is a bit sneaky.  NOTE there is no short-circuiting here.
@@ -108,8 +131,8 @@
 
 
 ;; inc/dec are useful primitives to have
-(set! inc  (fn* (n:number) (+ n 1)))
-(set! dec  (fn* (n:number) (- n 1)))
+(set! inc (fn* (n:number) (+ n 1)))
+(set! dec (fn* (n:number) (- n 1)))
 
 ;; We could also define the incr/decr operations as macros.
 (defmacro! incr (fn* (x) `(set! ~x (+ ~x 1))))
@@ -123,18 +146,20 @@
 
 ;; Return the last element of a list
 (set! last (fn* (lst:list)
-  (let* (c (cdr lst))
-    (if (! (nil? c))
-      (last c)
-      (car lst)))))
+                "last returns the last item in the specified list, it is the opposite of cdr."
+                (let* (c (cdr lst))
+                  (if (! (nil? c))
+                      (last c)
+                    (car lst)))))
 
 ;; Setup a simple function to run a loop N times
 ;;
 (set! repeat (fn* (n body)
-  (if (> n 0)
-      (do
-          (body n)
-          (repeat (- n 1) body)))))
+                  "Execute the supplied body of code N times."
+                  (if (> n 0)
+                      (do
+                          (body n)
+                          (repeat (- n 1) body)))))
 
 ;; A helper to apply a function to each key/value pair of a hash
 (set! apply-hash (fn* (hs:hash fun:function)
@@ -143,7 +168,9 @@
 
 
 ;; Count the length of a string
-(set! strlen (fn* (str:string) (length (split str "" ))))
+(set! strlen (fn* (str:string)
+                  "Calculate and return the length of the supplied string."
+                  (length (split str "" ))))
 
 
 ;; More mathematical functions relating to negative numbers.
@@ -156,13 +183,18 @@
 
 ;; Create ranges of numbers in a list
 (set! range (fn* (start:number end:number step:number)
-  (if (< start end)
-     (cons start (range (+ start step) end step))
-        ())))
+                 "Create a list of numbers between the start and end bounds, incrementing by the given offset each time."
+                 (if (< start end)
+                     (cons start (range (+ start step) end step))
+                   ())))
 
 ;; Create sequences from 0/1 to N
-(set! seq (fn* (n:number) (range 0 n 1)))
-(set! nat (fn* (n:number) (range 1 n 1)))
+(set! seq (fn* (n:number)
+               "Create, and return, list of number ranging from 0-N"
+               (range 0 n 1)))
+(set! nat (fn* (n:number)
+               "Create, and return, a list of numbers ranging from 1 to N."
+               (range 1 n 1)))
 
 
 ;; Remove items from a list where the predicate function is not T
@@ -184,20 +216,22 @@
 
 ;; Now define min/max using reduce
 (set! min (fn* (xs:list)
-  (if (nil? xs)
-    ()
-      (reduce xs
-        (lambda (a b)
-           (if (< a b) a b))
-              (car xs)))))
+               "Return the smallest integer from the list of numbers supplied."
+               (if (nil? xs)
+                   ()
+                 (reduce xs
+                         (lambda (a b)
+                           (if (< a b) a b))
+                         (car xs)))))
 
 (set! max (fn* (xs:list)
-  (if (nil? xs)
-    ()
-      (reduce xs
-        (lambda (a b)
-           (if (< a b) b a))
-              (car xs)))))
+               "Return the maximum integer from the list of numbers supplied."
+               (if (nil? xs)
+                   ()
+                 (reduce xs
+                         (lambda (a b)
+                           (if (< a b) b a))
+                         (car xs)))))
 
 
 ; O(n^2) behavior with linked lists
@@ -208,9 +242,10 @@
 
 
 (set! reverse (fn* (x:list)
-  (if (nil? x)
-    ()
-      (append (reverse (cdr x)) (car x)))))
+                   "Return a list containing all values in the supplied list, in reverse order."
+                   (if (nil? x)
+                       ()
+                     (append (reverse (cdr x)) (car x)))))
 
 ;;
 ;; This is either gross or cool.
@@ -279,16 +314,19 @@
 
 ;; Translate the elements of the string using the specified hash
 (set! translate (fn* (x:string hsh:hash)
-  (let* (chrs (split x ""))
-    (join (map chrs (lambda (x)
-                  (if (get hsh x)
-                      (get hsh x)
-                    x)))))))
+                     "Translate each character in the given string, via the means of the supplied lookup-table.  This is used by 'upper' and 'lower'."
+                     (let* (chrs (split x ""))
+                       (join (map chrs (lambda (x)
+                                         (if (get hsh x)
+                                             (get hsh x)
+                                           x)))))))
 
 ;; Convert the given string to upper-case, via the lookup table.
 (set! upper (fn* (x:string)
-                (translate x upper-table)))
+                 "Convert each character from the supplied string to upper-case, and return that string."
+                 (translate x upper-table)))
 
 ;; Convert the given string to upper-case, via the lookup table.
 (set! lower (fn* (x:string)
+                 "Convert each character from the supplied string to lower-case, and return that string."
                 (translate x lower-table)))

--- a/stdlib/stdlib.lisp
+++ b/stdlib/stdlib.lisp
@@ -11,18 +11,43 @@
 ;; There is a built in `type` function which returns the type of an object.
 ;;
 ;; Use this to define some simple methods to test argument-types
-(set! boolean?  (fn* (x) (eq (type x) "boolean")))
-(set! error?    (fn* (x) (eq (type x) "error")))
-(set! function? (fn* (x) (or
-                                (list
-                                   (eq (type x) "procedure(lisp)")
-                                   (eq (type x) "procedure(golang)")))))
-(set! hash?     (fn* (x) (eq (type x) "hash")))
-(set! macro?    (fn* (x) (eq (type x) "macro")))
-(set! list?     (fn* (x) (eq (type x) "list")))
-(set! number?   (fn* (x) (eq (type x) "number")))
-(set! string?   (fn* (x) (eq (type x) "string")))
-(set! symbol?   (fn* (x) (eq (type x) "symbol")))
+(set! boolean?  (fn* (x)
+                     "Returns true if the argument specified is a boolean value."
+                     (eq (type x) "boolean")))
+
+(set! error?    (fn* (x)
+                     "Returns true if the argument specified is an error-value."
+                     (eq (type x) "error")))
+
+(set! function? (fn* (x) "Returns true if the argument specified is a function, either a built-in function, or a user-written one."
+                     (or
+                      (list
+                       (eq (type x) "procedure(lisp)")
+                       (eq (type x) "procedure(golang)")))))
+
+(set! hash?     (fn* (x)
+                     "Returns true if the argument specified is a hash"
+                     (eq (type x) "hash")))
+
+(set! macro?    (fn* (x)
+                     "Returns true if the argument specified is a macro."
+                     (eq (type x) "macro")))
+
+(set! list?     (fn* (x)
+                     "Returns true if the argument specified is a list."
+                     (eq (type x) "list")))
+
+(set! number?   (fn* (x)
+                     "Returns true if the argument specified is a number."
+                     (eq (type x) "number")))
+
+(set! string?   (fn* (x)
+                     "Returns true if the argument specified is a string."
+                     (eq (type x) "string")))
+
+(set! symbol?   (fn* (x)
+                     "Returns true if the argument specified is a symbol."
+                     (eq (type x) "symbol")))
 
 ;; We've defined "<" in golang, we can now implement the missing
 ;; functions in terms of that:

--- a/stdlib/stdlib.lisp
+++ b/stdlib/stdlib.lisp
@@ -184,11 +184,25 @@
 
 
 ;; More mathematical functions relating to negative numbers.
-(set! neg  (fn* (n:number) (- 0 n)))
-(set! neg? (fn* (n:number) (< n 0)))
-(set! pos? (fn* (n:number) (> n 0)))
-(set! abs  (fn* (n:number) (if (neg? n) (neg n) n)))
-(set! sign (fn* (n:number) (if (neg? n) (neg 1) 1)))
+(set! neg  (fn* (n:number)
+                "Negate the supplied number, and return it."
+                (- 0 n)))
+
+(set! neg? (fn* (n:number)
+                "Return true if the supplied number is negative."
+                (< n 0)))
+
+(set! pos? (fn* (n:number)
+                "Return true if the supplied number is positive."
+                (> n 0)))
+
+(set! abs  (fn* (n:number)
+                "Return the absolute value of the supplied number."
+                (if (neg? n) (neg n) n)))
+
+(set! sign (fn* (n:number)
+                "Return 1 if the specified number is positive, and -1 if it is negative."
+                (if (neg? n) (neg 1) 1)))
 
 
 ;; Create ranges of numbers in a list


### PR DESCRIPTION
This pull-request, once complete, would close #25 by adding integrated help to our interpreter.

That means it should be possible for each function to contain a help-text describing it briefly, ideally with an example.

This help-text would be available at run-time, although we'd expect the most common way to view it would be to run `yal -h`.

TODO:

* Help text should be present for all built-in functions.
  * Examples, prefixed by two TABs too
* Add support for an optional argument for user-written functions.
  *  `(set! foo (fn* (x) "HELP GOES HERE" ...))`
  * Just like in emacs defun.