### PR TITLE
Allow easier aliasing.

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -500,6 +500,24 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 			// first token/symbol
 			switch listExp[0] {
 
+			// (alias ..)
+			case primitive.Symbol("alias"):
+				if len(listExp) != 3 {
+					return primitive.Error("Expected two arguments")
+				}
+
+				// Name we'll use
+				name := listExp[1]
+
+				// Existing function.
+				val := listExp[2]
+
+				old, ok := e.Get(val.ToString())
+				if ok {
+					e.Set(name.ToString(), old)
+				}
+				return primitive.Nil{}
+
 			// (do ..)
 			case primitive.Symbol("do"):
 				var ret primitive.Primitive

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -194,6 +194,10 @@ a
 		{`(split "steve" "")`, `(s t e v e)`},
 		{`(join (list "s" "t" "e" "v" "e"))`, `steve`},
 
+		// alias
+		{`(alias explode split) (explode "steve" "")`, `(s t e v e)`},
+		{`(alias ** #) (** 3 3)`, `27`},
+
 		// comparison
 		{"(< 1 3)", "#t"},
 		{"(< 10 3)", "#f"},
@@ -203,7 +207,7 @@ a
 		{"(= 10 10)", "#t"},
 		{"(= -1 -1)", "#t"},
 
-		// we have a LOT of built ins, but not 100
+		// we have a LOT of built ins, but not 200
 		{"(> (length (env))  10)", "#t"},
 		{"(> (length (env))  50)", "#t"},
 		{"(< (length (env)) 200)", "#t"},
@@ -265,6 +269,8 @@ a
 		{"{ :name { ", "nil"},
 		{"{ :age 333  ", "nil"},
 		{"}}}}}}", "nil"},
+
+		{"(alias foo)", "ERROR{Expected two arguments}"},
 
 		// try / catch
 		{"(try 3)", "ERROR{arity-error: not enough arguments for (try ..)}"},

--- a/primitive/procedure.go
+++ b/primitive/procedure.go
@@ -6,7 +6,6 @@ import "github.com/skx/yal/env"
 // a lisp-usable function implemented in golang.
 type GolangPrimitiveFn func(e *env.Environment, args []Primitive) Primitive
 
-
 // Procedure holds a user-defined function.
 //
 // This structure is used to hold both the built-in functions, implemented in

--- a/stdlib/mal.lisp
+++ b/stdlib/mal.lisp
@@ -105,12 +105,7 @@
                     0
                     )))
 
-
-;; Alias to (length)
-(set! count (fn* (arg)
-                 "Return the length of the supplied list. This is an alias for (length)."
-                 (length arg)))
-
+(alias count length)
 
 ;; Find the Nth item of a list
 (set! nth (fn* (lst:list i:number)

--- a/stdlib/stdlib.lisp
+++ b/stdlib/stdlib.lisp
@@ -73,40 +73,45 @@
 ;;
 ;; Here we create some helper functions for retrieving the various
 ;; parts of the date/time, as well as some aliases for ease of typing.
-(set! date:year (fn* ()
-                "Return the current year, as an integer."
-                (nth (date) 3)))
-(set! year date:year)
+(set! date:day (fn* ()
+               "Return the day of the current month, as an integer."
+               (nth (date) 1)))
 
 (set! date:month (fn* ()
                  "Return the number of the current month, as an integer."
                  (nth (date) 2)))
-(set! month date:month)
 
-(set! date:day (fn* ()
-               "Return the day of the current month, as an integer."
-               (nth (date) 1)))
-(set! day date:day)
 
 (set! date:weekday (fn* ()
                    "Return a string containing the current day of the week."
                    (nth (date) 0)))
-(set! weekday date:weekday)
+
+(set! date:year (fn* ()
+                "Return the current year, as an integer."
+                (nth (date) 3)))
+
+;; define legacy aliases
+(alias day     date:day)
+(alias month   date:month)
+(alias weekday date:weekday)
+(alias year    date:year)
 
 (set! time:hour (fn* ()
                 "Return the current hour, as an integer."
                 (nth (time) 0)))
-(set! hour time:hour)
 
 (set! time:minute (fn* ()
                   "Return the current minute, as an integer."
                   (nth (time) 1)))
-(set! minute time:minute)
 
 (set! time:second (fn* ()
                   "Return the current seconds, as an integer."
                   (nth (time) 2)))
-(set! second time:second)
+
+;; define legacy aliases
+(alias hour time:hour)
+(alias minute time:minute)
+(alias second time:second)
 
 (set! time:hms (fn* ()
                "Return the current time, formatted as 'HH:MM:SS', as a string."
@@ -184,6 +189,8 @@
 (set! ! (fn* (x)
              "Return the inverse/NOT of the given boolean value"
              (if x #f #t)))
+
+(alias not !)
 
 ;; Square root
 (set! sqrt (fn* (x:number)
@@ -446,5 +453,5 @@
                              (nil? info) ""
                              true (nth info 4)))))
 
-; Slurp used to be a primitive for reading file contents
-(set! slurp file:read)
+;; Define a legacy alias
+(alias slurp file:read)


### PR DESCRIPTION
Rather than using "(set! new-name old-name)", which works, we should use an "(alias new-name old-name)" function which expresses our intent more cleanly.

This closes #38.