### PR TITLE
Implemented directory:walk

### DIFF
--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -273,34 +273,6 @@ func dateFn(env *env.Environment, args []primitive.Primitive) primitive.Primitiv
 	return ret
 }
 
-// directoryFn returns whether the given path exists, and is a directory
-func directoryFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
-
-	// We only need a single argument
-	if len(args) != 1 {
-		return primitive.Error("invalid argument count")
-	}
-
-	// Which is a string
-	str, ok := args[0].(primitive.String)
-	if !ok {
-		return primitive.Error("argument not a string")
-	}
-
-	// Stat the entry
-	info, err := os.Stat(str.ToString())
-
-	// No error and isDir then true?  Otherwise false
-	//
-	// i.e. swallow errors
-	if err == nil {
-		if info.IsDir() {
-			return primitive.Bool(true)
-		}
-	}
-	return primitive.Bool(false)
-}
-
 // directoryEntriesFn returns the files beneath given path, recursively.
 func directoryEntriesFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 
@@ -328,6 +300,34 @@ func directoryEntriesFn(env *env.Environment, args []primitive.Primitive) primit
 	})
 
 	return res
+}
+
+// directoryFn returns whether the given path exists, and is a directory
+func directoryFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
+
+	// We only need a single argument
+	if len(args) != 1 {
+		return primitive.Error("invalid argument count")
+	}
+
+	// Which is a string
+	str, ok := args[0].(primitive.String)
+	if !ok {
+		return primitive.Error("argument not a string")
+	}
+
+	// Stat the entry
+	info, err := os.Stat(str.ToString())
+
+	// No error and isDir then true?  Otherwise false
+	//
+	// i.e. swallow errors
+	if err == nil {
+		if info.IsDir() {
+			return primitive.Bool(true)
+		}
+	}
+	return primitive.Bool(false)
 }
 
 // divideFn implements "/"

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -317,7 +317,7 @@ func directoryEntriesFn(env *env.Environment, args []primitive.Primitive) primit
 
 	var res primitive.List
 
-	filepath.Walk(pth.ToString(), func(path string, info os.FileInfo, err error) error {
+	_ = filepath.Walk(pth.ToString(), func(path string, info os.FileInfo, err error) error {
 
 		if err != nil {
 			return nil

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -108,6 +108,7 @@ func PopulateEnvironment(env *env.Environment) {
 	env.Set("contains?", &primitive.Procedure{F: containsFn, Help: helpMap["contains?"]})
 	env.Set("date", &primitive.Procedure{F: dateFn, Help: helpMap["date"]})
 	env.Set("directory?", &primitive.Procedure{F: directoryFn, Help: helpMap["directory?"]})
+	env.Set("directory:entries", &primitive.Procedure{F: directoryEntriesFn, Help: helpMap["directory:entries"]})
 	env.Set("eq", &primitive.Procedure{F: eqFn, Help: helpMap["eq"]})
 	env.Set("error", &primitive.Procedure{F: errorFn, Help: helpMap["error"]})
 	env.Set("exists?", &primitive.Procedure{F: existsFn, Help: helpMap["exists?"]})
@@ -298,6 +299,35 @@ func directoryFn(env *env.Environment, args []primitive.Primitive) primitive.Pri
 		}
 	}
 	return primitive.Bool(false)
+}
+
+// directoryEntriesFn returns the files beneath given path, recursively.
+func directoryEntriesFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
+
+	// We only need a single argument
+	if len(args) != 1 {
+		return primitive.Error("invalid argument count")
+	}
+
+	// Which is a string
+	pth, ok := args[0].(primitive.String)
+	if !ok {
+		return primitive.Error("argument not a string")
+	}
+
+	var res primitive.List
+
+	filepath.Walk(pth.ToString(), func(path string, info os.FileInfo, err error) error {
+
+		if err != nil {
+			return nil
+		}
+
+		res = append(res, primitive.String(path))
+		return nil
+	})
+
+	return res
 }
 
 // divideFn implements "/"

--- a/builtins/help.txt
+++ b/builtins/help.txt
@@ -47,6 +47,13 @@ See also: exists? file?
 Example: (print (directory? "/etc"))
 
 %%
+directory:entries
+
+directory:entries returns the names of all files/directories beneath the given
+path, recursively.  It is a helper function used to implement directory:walk
+
+See also: directory:walk, glob
+%%
 eq
 
 eq returns true if the two values supplied as parameters have the same type, and string representation.
@@ -122,6 +129,7 @@ glob
 
 glob returns files matching the given pattern, as a list.
 
+See also: directory:entries directory:walk
 Example: (print (glob "/etc/p*"))
 %%
 help

--- a/stdlib/stdlib.lisp
+++ b/stdlib/stdlib.lisp
@@ -455,3 +455,10 @@
 
 ;; Define a legacy alias
 (alias slurp file:read)
+
+
+;; Handy function to invoke a callback on files
+(set! directory:walk (fn* (path:string fn:function)
+                          "Invoke the specified callback on every file beneath the given path."
+
+                          (apply (directory:entries path) fn)))


### PR DESCRIPTION
Sample usage looks like this:

```
(directory:walk "/etc" (lambda (x)
                         (if (directory? x)
                             (print "Got directory: %s" x)
                           (print "Got file: %s" x)
                           )))
```

To avoid the complexity of adding this as a built-in form the implementation creates "directory:entries" to return the contents of the given path, recursively.

If we have a list of file/directories, and a function, we can just use apply to do the magic.

This closes #34.