### PR TITLE
100% consistency on argument-requirements.

### DIFF
--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -154,7 +154,7 @@ func archFn(env *env.Environment, args []primitive.Primitive) primitive.Primitiv
 func carFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 
 	if len(args) != 1 {
-		return primitive.Error("wrong number of arguments")
+		return primitive.ArityError()
 	}
 
 	// ensure we received a list
@@ -176,7 +176,7 @@ func carFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive
 func cdrFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 
 	if len(args) != 1 {
-		return primitive.Error("wrong number of arguments")
+		return primitive.ArityError()
 	}
 
 	// ensure we received a list
@@ -195,7 +195,7 @@ func cdrFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive
 func chrFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 
 	if len(args) != 1 {
-		return primitive.Error("wrong number of arguments")
+		return primitive.ArityError()
 	}
 
 	if _, ok := args[0].(primitive.Number); !ok {
@@ -211,7 +211,7 @@ func chrFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive
 // consFn implements (cons).
 func consFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	if len(args) < 1 {
-		return primitive.Error("wrong number of arguments")
+		return primitive.ArityError()
 	}
 
 	if len(args) == 1 {
@@ -231,7 +231,7 @@ func containsFn(env *env.Environment, args []primitive.Primitive) primitive.Prim
 
 	// We need a pair of arguments
 	if len(args) != 2 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// First is a Hash
@@ -279,7 +279,7 @@ func directoryEntriesFn(env *env.Environment, args []primitive.Primitive) primit
 
 	// We only need a single argument
 	if len(args) != 1 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// Which is a string
@@ -308,7 +308,7 @@ func directoryFn(env *env.Environment, args []primitive.Primitive) primitive.Pri
 
 	// We only need a single argument
 	if len(args) != 1 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// Which is a string
@@ -335,7 +335,7 @@ func directoryFn(env *env.Environment, args []primitive.Primitive) primitive.Pri
 func divideFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	// ensure we have at least one argument
 	if len(args) < 1 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// the first argument must be a number.
@@ -365,7 +365,7 @@ func divideFn(env *env.Environment, args []primitive.Primitive) primitive.Primit
 // eqFn implements "eq"
 func eqFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	if len(args) != 2 {
-		return primitive.Error("wrong number of arguments")
+		return primitive.ArityError()
 	}
 
 	a := args[0]
@@ -383,7 +383,7 @@ func eqFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive 
 // equalsFn implements "="
 func equalsFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	if len(args) != 2 {
-		return primitive.Error("wrong number of arguments")
+		return primitive.ArityError()
 	}
 
 	a := args[0]
@@ -404,7 +404,7 @@ func equalsFn(env *env.Environment, args []primitive.Primitive) primitive.Primit
 // errorFn implements "error"
 func errorFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	if len(args) != 1 {
-		return primitive.Error("wrong number of arguments")
+		return primitive.ArityError()
 	}
 	return primitive.Error(args[0].ToString())
 }
@@ -414,7 +414,7 @@ func existsFn(env *env.Environment, args []primitive.Primitive) primitive.Primit
 
 	// We only need a single argument
 	if len(args) != 1 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// Which is a string
@@ -481,8 +481,9 @@ func expandStr(input string) string {
 // expnFn implements "#"
 func expnFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	if len(args) != 2 {
-		return primitive.Error("wrong number of arguments")
+		return primitive.ArityError()
 	}
+
 	if _, ok := args[0].(primitive.Number); !ok {
 		return primitive.Error("argument not a number")
 	}
@@ -496,7 +497,7 @@ func expnFn(env *env.Environment, args []primitive.Primitive) primitive.Primitiv
 func fileFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	// We only need a single argument
 	if len(args) != 1 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// Which is a string
@@ -523,7 +524,7 @@ func fileFn(env *env.Environment, args []primitive.Primitive) primitive.Primitiv
 func fileLinesFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	// We only need a single argument
 	if len(args) != 1 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// Which is a string
@@ -556,7 +557,7 @@ func fileLinesFn(env *env.Environment, args []primitive.Primitive) primitive.Pri
 func fileReadFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	// We only need a single argument
 	if len(args) != 1 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// Which is a string
@@ -578,7 +579,7 @@ func fileReadFn(env *env.Environment, args []primitive.Primitive) primitive.Prim
 func fileStatFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	// We only need a single argument
 	if len(args) != 1 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// Which is a string
@@ -639,7 +640,7 @@ func getFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive
 
 	// We need two arguments
 	if len(args) != 2 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// First is a Hash
@@ -656,7 +657,7 @@ func getenvFn(env *env.Environment, args []primitive.Primitive) primitive.Primit
 
 	// If we have only a single argument
 	if len(args) != 1 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// Which is a string
@@ -674,7 +675,7 @@ func globFn(env *env.Environment, args []primitive.Primitive) primitive.Primitiv
 
 	// If we have only a single argument
 	if len(args) != 1 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// Which is a string
@@ -703,7 +704,7 @@ func globFn(env *env.Environment, args []primitive.Primitive) primitive.Primitiv
 func helpFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	// We need a single argument
 	if len(args) != 1 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// Which is a function
@@ -734,7 +735,7 @@ func joinFn(env *env.Environment, args []primitive.Primitive) primitive.Primitiv
 
 	// We require one argument
 	if len(args) != 1 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// The argument must be a list
@@ -756,7 +757,7 @@ func keysFn(env *env.Environment, args []primitive.Primitive) primitive.Primitiv
 
 	// We need a single argument
 	if len(args) != 1 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// First is a Hash
@@ -797,7 +798,7 @@ func listFn(env *env.Environment, args []primitive.Primitive) primitive.Primitiv
 // ltFn implements "<"
 func ltFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	if len(args) != 2 {
-		return primitive.Error("wrong number of arguments")
+		return primitive.ArityError()
 	}
 
 	if _, ok := args[0].(primitive.Number); !ok {
@@ -814,7 +815,7 @@ func matchFn(env *env.Environment, args []primitive.Primitive) primitive.Primiti
 
 	// We need two arguments
 	if len(args) != 2 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// First argument is a string (which is a regexp)
@@ -869,7 +870,7 @@ func minusFn(env *env.Environment, args []primitive.Primitive) primitive.Primiti
 
 	// ensure we have at least one argument
 	if len(args) < 1 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// the first argument must be a number.
@@ -895,7 +896,7 @@ func minusFn(env *env.Environment, args []primitive.Primitive) primitive.Primiti
 // modFn implements "%"
 func modFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	if len(args) != 2 {
-		return primitive.Error("wrong number of arguments")
+		return primitive.ArityError()
 	}
 	if _, ok := args[0].(primitive.Number); !ok {
 		return primitive.Error("argument not a number")
@@ -921,7 +922,7 @@ func msFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive 
 func multiplyFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	// ensure we have at least one argument
 	if len(args) < 1 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// the first argument must be a number.
@@ -947,7 +948,7 @@ func multiplyFn(env *env.Environment, args []primitive.Primitive) primitive.Prim
 // nilFn implements nil?
 func nilFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	if len(args) != 1 {
-		return primitive.Error("wrong number of arguments")
+		return primitive.ArityError()
 	}
 
 	// nil is nil (yeah, really)
@@ -972,7 +973,7 @@ func nowFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive
 func ordFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 
 	if len(args) != 1 {
-		return primitive.Error("wrong number of arguments")
+		return primitive.ArityError()
 	}
 
 	if _, ok := args[0].(primitive.String); !ok {
@@ -1000,7 +1001,7 @@ func plusFn(env *env.Environment, args []primitive.Primitive) primitive.Primitiv
 
 	// ensure we have at least one argument
 	if len(args) < 1 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// the first argument must be a number.
@@ -1027,7 +1028,7 @@ func plusFn(env *env.Environment, args []primitive.Primitive) primitive.Primitiv
 func printFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	// no args
 	if len(args) < 1 {
-		return primitive.Error("wrong number of arguments")
+		return primitive.ArityError()
 	}
 
 	// one arg
@@ -1059,7 +1060,7 @@ func printFn(env *env.Environment, args []primitive.Primitive) primitive.Primiti
 // randomFn implements (random).
 func randomFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	if len(args) != 1 {
-		return primitive.Error("wrong number of arguments")
+		return primitive.ArityError()
 	}
 
 	// ensure we received a number
@@ -1078,7 +1079,7 @@ func setFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive
 
 	// We need three arguments
 	if len(args) != 3 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// First is a Hash
@@ -1096,7 +1097,7 @@ func shellFn(env *env.Environment, args []primitive.Primitive) primitive.Primiti
 
 	// We need one argument
 	if len(args) != 1 {
-		return primitive.Error("wrong number of arguments")
+		return primitive.ArityError()
 	}
 
 	// The argument must be a list
@@ -1138,7 +1139,7 @@ func shellFn(env *env.Environment, args []primitive.Primitive) primitive.Primiti
 func sortFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	// If we have only a single argument
 	if len(args) != 1 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// Which is a list
@@ -1182,7 +1183,7 @@ func splitFn(env *env.Environment, args []primitive.Primitive) primitive.Primiti
 
 	// We require two arguments
 	if len(args) != 2 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// Both arguments must be strings
@@ -1210,7 +1211,7 @@ func sprintfFn(env *env.Environment, args []primitive.Primitive) primitive.Primi
 
 	// we need 2+ arguments
 	if len(args) < 2 {
-		return primitive.Error("wrong number of arguments")
+		return primitive.ArityError()
 	}
 
 	// OK format-string
@@ -1231,7 +1232,7 @@ func sprintfFn(env *env.Environment, args []primitive.Primitive) primitive.Primi
 // strFn implements "str"
 func strFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	if len(args) != 1 {
-		return primitive.Error("wrong number of arguments")
+		return primitive.ArityError()
 	}
 	return primitive.String(args[0].ToString())
 }
@@ -1256,7 +1257,7 @@ func timeFn(env *env.Environment, args []primitive.Primitive) primitive.Primitiv
 // typeFn implements "type"
 func typeFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	if len(args) != 1 {
-		return primitive.Error("wrong number of arguments")
+		return primitive.ArityError()
 	}
 	return primitive.String(args[0].Type())
 }
@@ -1266,7 +1267,7 @@ func valsFn(env *env.Environment, args []primitive.Primitive) primitive.Primitiv
 
 	// We need a single argument
 	if len(args) != 1 {
-		return primitive.Error("invalid argument count")
+		return primitive.ArityError()
 	}
 
 	// First is a Hash

--- a/builtins/builtins_test.go
+++ b/builtins/builtins_test.go
@@ -50,7 +50,7 @@ func TestCar(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "number of arguments") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -109,7 +109,7 @@ func TestCdr(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "number of arguments") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -167,7 +167,7 @@ func TestChr(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "wrong number of arguments") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one:%s", out)
 	}
 
@@ -210,7 +210,7 @@ func TestCons(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "wrong number of arguments") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -404,7 +404,7 @@ func TestDirectory(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "argument count") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -566,7 +566,7 @@ func TestDivide(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "invalid argument count") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -674,7 +674,7 @@ func TestEq(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "number of arguments") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -741,7 +741,7 @@ func TestEquals(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "number of arguments") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -824,7 +824,7 @@ func TestError(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "number of arguments") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -945,7 +945,7 @@ func TestExpn(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "number of arguments") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -1304,7 +1304,7 @@ func TestGetenv(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "invalid argument count") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -1484,7 +1484,7 @@ func TestJoin(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "invalid argument count") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -1624,7 +1624,7 @@ func TestLt(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "number of arguments") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -1687,7 +1687,7 @@ func TestMatches(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "invalid argument count") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one")
 	}
 
@@ -1784,7 +1784,7 @@ func TestMinus(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "invalid argument count") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -1846,7 +1846,7 @@ func TestMod(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "number of arguments") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -1946,7 +1946,7 @@ func TestMultiply(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "invalid argument count") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -2008,7 +2008,7 @@ func TestNil(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "number of arguments") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -2085,7 +2085,7 @@ func TestOrd(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "wrong number of arguments") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one:%s", out)
 	}
 
@@ -2157,7 +2157,7 @@ func TestPlus(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "invalid argument count") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -2218,7 +2218,7 @@ func TestPrint(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "wrong number of arguments") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -2261,7 +2261,7 @@ func TestRandom(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "wrong number of arguments") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -2376,7 +2376,7 @@ func TestSort(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "invalid argument count") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -2444,7 +2444,7 @@ func TestSplit(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "invalid argument count") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -2507,7 +2507,7 @@ func TestSprintf(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "wrong number of arguments") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
@@ -2562,7 +2562,7 @@ func TestType(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "number of arguments") {
+	if e != primitive.ArityError() {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -503,7 +503,7 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 			// (alias ..)
 			case primitive.Symbol("alias"):
 				if len(listExp) != 3 {
-					return primitive.Error("Expected two arguments")
+					return primitive.ArityError()
 				}
 
 				// Name we'll use
@@ -529,7 +529,7 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 			// (read
 			case primitive.Symbol("read"):
 				if len(listExp) != 2 {
-					return primitive.Error("Expected only a single argument")
+					return primitive.ArityError()
 				}
 
 				arg := listExp[1].ToString()
@@ -556,7 +556,7 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 			case primitive.Symbol("eval"):
 
 				if len(listExp) != 2 {
-					return primitive.Error("Expected only a single argument")
+					return primitive.ArityError()
 				}
 
 				switch val := listExp[1].(type) {
@@ -600,7 +600,7 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 			// (define
 			case primitive.Symbol("define"), primitive.Symbol("def!"):
 				if len(listExp) < 3 {
-					return primitive.Error("arity-error: not enough arguments for (define ..)")
+					return primitive.ArityError()
 				}
 				symb, ok := listExp[1].(primitive.Symbol)
 				if ok {
@@ -614,7 +614,7 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 			// (defmacro!
 			case primitive.Symbol("defmacro!"):
 				if len(listExp) < 3 {
-					return primitive.Error("arity-error: not enough arguments for (defmacro! ..)")
+					return primitive.ArityError()
 				}
 
 				// name of macro
@@ -639,7 +639,7 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 			// (set!
 			case primitive.Symbol("set!"):
 				if len(listExp) < 3 {
-					return primitive.Error("arity-error: not enough arguments for (set! ..)")
+					return primitive.ArityError()
 				}
 
 				// Get the symbol we're gonna set
@@ -662,14 +662,14 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 			// (quote ..)
 			case primitive.Symbol("quote"):
 				if len(listExp) < 2 {
-					return primitive.Error("arity-error: not enough arguments for (quote")
+					return primitive.ArityError()
 				}
 				return listExp[1]
 
 			// (quasiquote ..)
 			case primitive.Symbol("quasiquote"):
 				if len(listExp) < 2 {
-					return primitive.Error("arity-error: not enough arguments for (quasiquote")
+					return primitive.ArityError()
 				}
 				exp = ev.quasiquote(listExp[1])
 				goto repeat_eval
@@ -677,14 +677,14 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 			// (macroexpand ..)
 			case primitive.Symbol("macroexpand"):
 				if len(listExp) < 2 {
-					return primitive.Error("arity-error: not enough arguments for (macroexpand")
+					return primitive.ArityError()
 				}
 				return ev.macroExpand(listExp[1], e)
 
 			// (let
 			case primitive.Symbol("let"):
 				if len(listExp) < 2 {
-					return primitive.Error("arity-error: not enough arguments for (let ..)")
+					return primitive.ArityError()
 				}
 
 				newEnv := env.NewEnvironment(e)
@@ -702,7 +702,7 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 					}
 
 					if len(bl) < 2 {
-						return primitive.Error("arity-error: binding list had missing arguments")
+						return primitive.ArityError()
 					}
 					// get the value
 					bindingVal := ev.eval(bl[1], newEnv, expandMacro)
@@ -732,7 +732,7 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 				// let should have two entries
 
 				if len(listExp) < 2 {
-					return primitive.Error("arity-error: not enough arguments for (let* ..)")
+					return primitive.ArityError()
 				}
 
 				newEnv := env.NewEnvironment(e)
@@ -806,7 +806,7 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 			// (if
 			case primitive.Symbol("if"):
 				if len(listExp) < 3 {
-					return primitive.Error("arity-error: not enough arguments for (if ..)")
+					return primitive.ArityError()
 				}
 
 				test := ev.eval(listExp[1], e, expandMacro)
@@ -834,7 +834,7 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 			// (try
 			case primitive.Symbol("try"):
 				if len(listExp) < 3 {
-					return primitive.Error("arity-error: not enough arguments for (try ..)")
+					return primitive.ArityError()
 				}
 
 				// first expression is what to execute: a list
@@ -883,7 +883,7 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 
 				// ensure we have arguments
 				if len(listExp) != 3 && len(listExp) != 4 {
-					return primitive.Error("wrong number of arguments")
+					return primitive.ArityError()
 				}
 
 				// ensure that our arguments are a list
@@ -1018,7 +1018,7 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 				// Unless variadic arguments are expected, because in that case "anything" is fine.
 				//
 				if len(args) < min && (variadic == "") {
-					return primitive.Error(fmt.Sprintf("arity-error - function '%s' requires %d argument(s), %d provided", listExp[0].ToString(), min, len(args)))
+					return primitive.ArityError()
 				}
 
 				// Create a new environment/scope to set the

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -216,33 +216,33 @@ a
 		// errors
 		{"(invalid)", "ERROR{argument 'invalid' not a function}"},
 		{"(set! 3 4)", "ERROR{tried to set a non-symbol 3}"},
-		{"(eval 'foo 'bar)", "ERROR{Expected only a single argument}"},
+		{"(eval 'foo 'bar)", primitive.ArityError().ToString()},
 		{"(eval 3)", "ERROR{unexpected type for eval %!V(primitive.Number=3).}"},
 		{"(let 3)", "ERROR{argument is not a list, got 3}"},
 		{"(let ((0 0)) )", "ERROR{binding name is not a symbol, got 0}"},
-		{"(let ((0 )) )", "ERROR{arity-error: binding list had missing arguments}"},
+		{"(let ((0 )) )", primitive.ArityError().ToString()},
 		{"(let (3 3) )", "ERROR{binding value is not a list, got 3}"},
 
-		{"(let*)", "ERROR{arity-error: not enough arguments for (let* ..)}"},
+		{"(let*)", primitive.ArityError().ToString()},
 		{"(let* 32)", "ERROR{argument is not a list, got 32}"},
 		{"(let* (a 3 b))", "ERROR{list for (len*) must have even length, got [a 3 b]}"},
 		{"(let* (a 3 3 b))", "ERROR{binding name is not a symbol, got 3}"},
 
-		{"(error )", "ERROR{wrong number of arguments}"},
-		{"(quote )", "ERROR{arity-error: not enough arguments for (quote}"},
-		{"(quasiquote )", "ERROR{arity-error: not enough arguments for (quasiquote}"},
-		{"(macroexpand )", "ERROR{arity-error: not enough arguments for (macroexpand}"},
-		{"(if )", "ERROR{arity-error: not enough arguments for (if ..)}"},
+		{"(error )", primitive.ArityError().ToString()},
+		{"(quote )", primitive.ArityError().ToString()},
+		{"(quasiquote )", primitive.ArityError().ToString()},
+		{"(macroexpand )", primitive.ArityError().ToString()},
+		{"(if )", primitive.ArityError().ToString()},
 		{"(if (/ 1 0) #t #f)", "ERROR{attempted division by zero}"},
-		{"(define )", "ERROR{arity-error: not enough arguments for (define ..)}"},
+		{"(define )", primitive.ArityError().ToString()},
 		{"(define \"steve\" 3)}", "ERROR{Expected a symbol, got steve}"},
-		{"(lambda )}", "ERROR{wrong number of arguments}"},
+		{"(lambda )}", primitive.ArityError().ToString()},
 		{"(lambda 3 4)}", "ERROR{expected a list for arguments, got 3}"},
 		{"(define sq (lambda (x) (* x x))) (sq)", "ERROR{arity-error - function 'sq' requires 1 argument(s), 0 provided}"},
 		{"(print (/ 3 0))", "ERROR{error expanding argument [/ 3 0] for call to (print ..): ERROR{attempted division by zero}}"},
 		{"(lambda (x 3) (nil))}", "ERROR{expected a symbol for an argument, got 3}"},
-		{"(set! )", "ERROR{arity-error: not enough arguments for (set! ..)}"},
-		{"(let )", "ERROR{arity-error: not enough arguments for (let ..)}"},
+		{"(set! )", primitive.ArityError().ToString()},
+		{"(let )", primitive.ArityError().ToString()},
 		{`
 (define fizz (lambda (n:number)
   (cond
@@ -253,11 +253,11 @@ a
 `, "ERROR{attempted division by zero}"},
 		{"(error \"CAKE-FAIL\")", "ERROR{CAKE-FAIL}"},
 
-		{"(defmacro!)", "ERROR{arity-error: not enough arguments for (defmacro! ..)}"},
+		{"(defmacro!)", primitive.ArityError().ToString()},
 		{"(defmacro! 1 2)", "ERROR{Expected a symbol, got 1}"},
 		{"(defmacro! foo 2)", "ERROR{expected a function body for (defmacro..), got 2}"},
 
-		{"(read foo bar)", "ERROR{Expected only a single argument}"},
+		{"(read foo bar)", primitive.ArityError().ToString()},
 		{"(read \")\")", "ERROR{failed to read ):unexpected ')'}"},
 		{"(read \"}\")", "ERROR{failed to read }:unexpected '}'}"},
 		{"'", "nil"},
@@ -271,10 +271,10 @@ a
 		{"{ :age 333  ", "nil"},
 		{"}}}}}}", "nil"},
 
-		{"(alias foo)", "ERROR{Expected two arguments}"},
+		{"(alias foo)", primitive.ArityError().ToString()},
 
 		// try / catch
-		{"(try 3)", "ERROR{arity-error: not enough arguments for (try ..)}"},
+		{"(try 3)", primitive.ArityError().ToString()},
 		{"(try 3 3)", "ERROR{expected a list for argument, got 3}"},
 		{"(try (/ 1 0) 3)", "ERROR{expected a list for argument, got 3}"},
 		{"(try (/ 1 0) (/ 1 0) (/ 3 9))", "ERROR{catch list should begin with 'catch', got [/ 1 0]}"},

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -116,27 +116,23 @@ func FuzzYAL(f *testing.F) {
 	// Some programs are obviously invalid though, so we don't want to
 	// report those known-bad things.
 	known := []string{
-		"not a function",
+		"arityerror",
+		"deadline exceeded", // context timeout
 		"division by zero",
-		"arity-error",
-		"wrong number of arguments",
-		"invalid argument count",
-		"not a number",
-		"not a list",
-		"not a string",
-		"expected a symbol",
-		"expected a list",
 		"error expanding argument",
-		"is not a symbol",
-		"expected only a single argument", // (eval
-		"deadline exceeded",               // context timeout
-		"unexpected type for eval",        // (eval
-		"type-validation failed",
-		"unknown type-specification",
-		"not a hash",
-		"recursion limit",
 		"expected a function body",
+		"expected a list",
+		"expected a symbol",
+		"is not a symbol",
 		"must have even length",
+		"not a function",
+		"not a hash",
+		"not a list",
+		"not a number",
+		"not a string",
+		"recursion limit",
+		"type-validation failed",
+		"unexpected type",
 	}
 
 	f.Fuzz(func(t *testing.T, input []byte) {

--- a/primitive/error.go
+++ b/primitive/error.go
@@ -12,3 +12,9 @@ func (e Error) ToString() string {
 func (e Error) Type() string {
 	return "error"
 }
+
+// ArityError is the error raised when a function, or special form,
+// is invoked with the wrong number of arguments.
+func ArityError() Error {
+	return Error("ArityError - Unexpected argument count")
+}

--- a/primitive/primitive_test.go
+++ b/primitive/primitive_test.go
@@ -31,6 +31,11 @@ func TestError(t *testing.T) {
 	if error.ToString() != "ERROR{no-cheese}" {
 		t.Fatalf("error->String had wrong result")
 	}
+
+	if !strings.Contains(ArityError().ToString(), "Arity") {
+		t.Fatalf("arity-error is non-obvious")
+	}
+
 }
 
 func TestIsNil(t *testing.T) {


### PR DESCRIPTION
This pull-request updates things such that we use a fixed/known error when arity-errors are raised.

No more split between:

* invalid argument count

And

* wrong number of arguments

Now we just use primitive.ArityError() in all situations.