### PR TITLE
Allow (= ...) to accept multiple arguments.

### DIFF
--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -71,10 +71,12 @@ Things you'll find here include:
   * Subtraction function.
 * `/`
   * Division function.
+  * Note that if only a single value is specified the reciprocal is returned - i.e. "(/ 3)" is equal to "1/3".
 * `<`
   * Less-than function.
 * `=`
   * Numerical comparison function.
+  * Note that multiple arguments are supported, not just two.
 * `arch`
   * Return the operating system architecture.
 * `car`

--- a/builtins/builtins_test.go
+++ b/builtins/builtins_test.go
@@ -697,7 +697,7 @@ func TestEnsureHelpPresent(t *testing.T) {
 	}
 }
 
-// TestEq tests "eq"
+// TestEq tests "eq" (non-numerical equality)
 func TestEq(t *testing.T) {
 
 	// No arguments
@@ -764,7 +764,7 @@ func TestEq(t *testing.T) {
 	}
 }
 
-// TestEquals tests "="
+// TestEquals tests "=" (numerical equality)
 func TestEquals(t *testing.T) {
 
 	// No arguments
@@ -797,9 +797,32 @@ func TestEquals(t *testing.T) {
 	}
 
 	//
+	// Now a real one: equal - but multiple values
+	//
+	out = equalsFn(ENV, []primitive.Primitive{
+		primitive.Number(9),
+		primitive.Number(9),
+		primitive.Number(9),
+		primitive.Number(9),
+		primitive.Number(9),
+		primitive.Number(9),
+	})
+
+	// Will work
+	n, ok2 = out.(primitive.Bool)
+	if !ok2 {
+		t.Fatalf("expected bool, got %v", out)
+	}
+	if n != true {
+		t.Fatalf("got wrong result")
+	}
+
+	//
 	// Now a real one: unequal values
 	//
 	out = equalsFn(ENV, []primitive.Primitive{
+		primitive.Number(99),
+		primitive.Number(9),
 		primitive.Number(99),
 		primitive.Number(9),
 	})
@@ -814,11 +837,14 @@ func TestEquals(t *testing.T) {
 	}
 
 	//
-	// Now with wrong types
+	// Now with wrong types - last one is wrong
 	//
 	out = equalsFn(ENV, []primitive.Primitive{
-		primitive.Number(9),
-		primitive.String("9"),
+		primitive.Number(1),
+		primitive.Number(2),
+		primitive.Number(3),
+		primitive.Number(4),
+		primitive.String("5"),
 	})
 
 	e, ok = out.(primitive.Error)
@@ -837,7 +863,7 @@ func TestEquals(t *testing.T) {
 		primitive.Number(9),
 	})
 
-	// Will work
+	// Will report an error
 	e, ok = out.(primitive.Error)
 	if !ok {
 		t.Fatalf("expected error, got %v", out)

--- a/builtins/help.txt
+++ b/builtins/help.txt
@@ -21,10 +21,14 @@ Divides all arguments present with the first number.
 Return true if a is less than b.
 %%
 =
-returns true if the numerical values a and b are equal.
+returns true if the numerical values supplied are all equal to each other.
+
+Note that multiple values may be specified, so it is possible to compare
+three, or more, values as per the second example below.
 
 See also: eq
 Example : (print (= 3 a))
+Example : (print (= 3 a b))
 %%
 abs
 Return the absolute value of the supplied number.


### PR DESCRIPTION
The numerical-equality function "(=..)" previously supported only two values.  Now we support multiple values.

This updates #53, but does not close it until we've implemented the corresponding inequality test.