### PR TITLE
Windows build

### DIFF
--- a/.github/build
+++ b/.github/build
@@ -8,7 +8,7 @@ D=$(pwd)
 #
 # We build on multiple platforms/archs
 #
-BUILD_PLATFORMS="linux darwin freebsd"
+BUILD_PLATFORMS="linux darwin freebsd windows"
 BUILD_ARCHS="amd64 386"
 
 # For each platform

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -19,7 +19,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/skx/yal/env"
@@ -631,10 +630,16 @@ func fileStatFn(env *env.Environment, args []primitive.Primitive) primitive.Prim
 	UID := os.Getuid()
 	GID := os.Getgid()
 
-	// But if we can get the "real" values, then use them.
-	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
-		UID = int(stat.Uid)
-		GID = int(stat.Gid)
+	// Get the UID in a non-portable way
+	u, e := getUID(info)
+	if e == nil {
+		UID = u
+	}
+
+	// Get the GID in a non-portable way
+	g, e := getGID(info)
+	if e == nil {
+		GID = g
 	}
 
 	var res primitive.List

--- a/builtins/builtins_shell_test.go
+++ b/builtins/builtins_shell_test.go
@@ -1,5 +1,5 @@
-//go:build !windows && !darwin
-// +build !windows,!darwin
+//go:build !windows
+// +build !windows
 
 package builtins
 

--- a/builtins/file_info_unix.go
+++ b/builtins/file_info_unix.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+package builtins
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// getUID returns the owner of the file, from the extended information
+// available after a stat.
+//
+// This is in a seperate file so that we can build upon Windows systems.
+func getUID(info os.FileInfo) (int, error) {
+
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		return int(stat.Uid), nil
+	}
+	return 0, fmt.Errorf("not found")
+}
+
+// getGID returns the group of the file, from the extended information
+// available after a stat.
+//
+// This is in a seperate file so that we can build upon Windows systems.
+func getGID(info os.FileInfo) (int, error) {
+
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		return int(stat.Gid), nil
+	}
+	return 0, fmt.Errorf("not found")
+}

--- a/builtins/file_info_unix.go
+++ b/builtins/file_info_unix.go
@@ -3,31 +3,29 @@
 package builtins
 
 import (
-	"fmt"
 	"os"
 	"syscall"
 )
 
-// getUID returns the owner of the file, from the extended information
-// available after a stat.
-//
-// This is in a seperate file so that we can build upon Windows systems.
-func getUID(info os.FileInfo) (int, error) {
-
-	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
-		return int(stat.Uid), nil
-	}
-	return 0, fmt.Errorf("not found")
-}
-
 // getGID returns the group of the file, from the extended information
-// available after a stat.
+// available after a stat - that is not portable to Windows though.
 //
-// This is in a seperate file so that we can build upon Windows systems.
+// This is in a separate file so that we use build-tags to build code
+// appropriately.
 func getGID(info os.FileInfo) (int, error) {
 
-	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
-		return int(stat.Gid), nil
-	}
-	return 0, fmt.Errorf("not found")
+	stat, _ := info.Sys().(*syscall.Stat_t)
+	return int(stat.Gid), nil
+}
+
+
+// getUID returns the owner of the file, from the extended information
+// available after a stat - that is not portable to Windows though.
+//
+// This is in a separate file so that we use build-tags to build code
+// appropriately.
+func getUID(info os.FileInfo) (int, error) {
+
+	stat, _ := info.Sys().(*syscall.Stat_t)
+	return int(stat.Uid), nil
 }

--- a/builtins/file_info_windows.go
+++ b/builtins/file_info_windows.go
@@ -7,20 +7,28 @@ import (
 	"os"
 )
 
-// getUID returns the owner of the file, from the extended information
-// available after a stat.
+// getGID should return the group of the file, from the extended information
+// available after a stat, however on Windows platforms that doesn't work
+// in the obvious way.
 //
-// This is in a seperate file so that we can build upon Windows systems.
-func getUID(info os.FileInfo) (int, error) {
+// Here we just return an error to make that apparent to the caller.
+//
+// This is in a separate file so that we use build-tags to build code
+// appropriately.
+func getGID(info os.FileInfo) (int, error) {
 
 	return 0, fmt.Errorf("not found")
 }
 
-// getGID returns the group of the file, from the extended information
-// available after a stat.
+// getUID should return the owner of the file, from the extended information
+// available after a stat, however on Windows platforms that doesn't work
+// in the obvious way.
 //
-// This is in a seperate file so that we can build upon Windows systems.
-func getGID(info os.FileInfo) (int, error) {
+// Here we just return an error to make that apparent to the caller.
+//
+// This is in a separate file so that we use build-tags to build code
+// appropriately.
+func getUID(info os.FileInfo) (int, error) {
 
 	return 0, fmt.Errorf("not found")
 }

--- a/builtins/file_info_windows.go
+++ b/builtins/file_info_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package builtins
+
+import (
+	"fmt"
+	"os"
+)
+
+// getUID returns the owner of the file, from the extended information
+// available after a stat.
+//
+// This is in a seperate file so that we can build upon Windows systems.
+func getUID(info os.FileInfo) (int, error) {
+
+	return 0, fmt.Errorf("not found")
+}
+
+// getGID returns the group of the file, from the extended information
+// available after a stat.
+//
+// This is in a seperate file so that we can build upon Windows systems.
+func getGID(info os.FileInfo) (int, error) {
+
+	return 0, fmt.Errorf("not found")
+}


### PR DESCRIPTION
Restore the build for Windows systems.

Unfortunately we broke that, right before the release, with the introduction of the non-portable syscall to fetch the UID/GID of a file's owner.

Re-implement the syscall in a dedicated pair of files, with build-tags, so things work on either Windows or non-Windows.