### PR TITLE
64 characters

### DIFF
--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -101,6 +101,8 @@ Things you'll find here include:
   * Return the first item of a list.
 * `cdr`
   * Return all items of the list, except the first.
+* `char=`
+  * Return true if the supplied values are characters, equal in value.
 * `chr`
   * Return the ASCII character of the given number.
 * `cons`
@@ -120,6 +122,8 @@ Things you'll find here include:
   * Return an error.
 * `exists?`
   * Does the given path exist?
+* `explode`
+  * Convert the supplied string to a list of characters.
 * `file?`
   * Does the given path exist, and is it not a directory?
 * `file:lines`
@@ -156,7 +160,7 @@ Things you'll find here include:
 * `now`
   * Return the number of seconds past the Unix Epoch.
 * `ord`
-  * Return the ASCII code of the specified character.
+  * Return the ASCII code of the specified character, or the first character of the supplied string.
 * `os`
   * Return a string describing the current operating-system.
 * `print`

--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -111,6 +111,14 @@ Things you'll find here include:
   * Return all items of the list, except the first.
 * `char=`
   * Return true if the supplied values are characters, equal in value.
+* `char<`
+  * Return true if the first character is less than the second.
+* `char<=`
+  * Return true if the first character is less than, or equal to the second.
+* `char>`
+  * Return true if the first character is greater than the second.
+* `char>=`
+  * Return true if the first character is greater than, or equal to the second.
 * `chr`
   * Return the ASCII character of the given number.
 * `cons`

--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -19,7 +19,7 @@ the help file, to see further details.  This is just intended as a summary.
 ## Symbols
 
 The only notable special symbols are the following strings which
-represent the nil value. and ourboolean values.
+represent the nil value. and our boolean values.
 
 * `nil`
   * The nil value.
@@ -28,7 +28,15 @@ represent the nil value. and ourboolean values.
 * `#f`
   * `false` is also available as an alias.
 
-In the future we _might_ support characters, via \#A, etc.
+Characters are specified via the `#\X` syntax, for escaped characters you just need to add the escape:
+
+* `#\a` -> "a"
+* `#\b` -> "b"
+* ..
+* `#\X` -> "X"
+* `#\\n` -> newline
+* `#\\t` -> tab
+
 
 
 

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -103,6 +103,7 @@ func PopulateEnvironment(env *env.Environment) {
 	env.Set("car", &primitive.Procedure{F: carFn, Help: helpMap["car"], Args: []primitive.Symbol{primitive.Symbol("list")}})
 	env.Set("cdr", &primitive.Procedure{F: cdrFn, Help: helpMap["cdr"], Args: []primitive.Symbol{primitive.Symbol("list")}})
 	env.Set("char=", &primitive.Procedure{F: charEqualsFn, Help: helpMap["char="], Args: []primitive.Symbol{primitive.Symbol("a"), primitive.Symbol("b")}})
+	env.Set("char<", &primitive.Procedure{F: charLtFn, Help: helpMap["char<"], Args: []primitive.Symbol{primitive.Symbol("a"), primitive.Symbol("b")}})
 	env.Set("chr", &primitive.Procedure{F: chrFn, Help: helpMap["chr"], Args: []primitive.Symbol{primitive.Symbol("num")}})
 	env.Set("cons", &primitive.Procedure{F: consFn, Help: helpMap["cons"], Args: []primitive.Symbol{primitive.Symbol("a"), primitive.Symbol("b")}})
 	env.Set("contains?", &primitive.Procedure{F: containsFn, Help: helpMap["contains?"], Args: []primitive.Symbol{primitive.Symbol("hash"), primitive.Symbol("key")}})
@@ -234,6 +235,25 @@ func charEqualsFn(env *env.Environment, args []primitive.Primitive) primitive.Pr
 	}
 
 	return ret
+}
+
+
+// charLtFn implements (char<)
+func charLtFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
+	if len(args) != 2 {
+		return primitive.ArityError()
+	}
+
+	a, ok1 := args[0].(primitive.Character)
+	if !ok1 {
+		return primitive.Error("argument not a character")
+	}
+
+	b, ok2 := args[1].(primitive.Character);
+	if !ok2 {
+		return primitive.Error("argument not a character")
+	}
+	return primitive.Bool(a < b)
 }
 
 // chrFn is the implementation of (chr ..)

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -111,6 +111,7 @@ func PopulateEnvironment(env *env.Environment) {
 	env.Set("eq", &primitive.Procedure{F: eqFn, Help: helpMap["eq"], Args: []primitive.Symbol{primitive.Symbol("a"), primitive.Symbol("b")}})
 	env.Set("error", &primitive.Procedure{F: errorFn, Help: helpMap["error"], Args: []primitive.Symbol{primitive.Symbol("message")}})
 	env.Set("exists?", &primitive.Procedure{F: existsFn, Help: helpMap["exists?"], Args: []primitive.Symbol{primitive.Symbol("path")}})
+	env.Set("explode", &primitive.Procedure{F: explodeFn, Help: helpMap["explode"], Args: []primitive.Symbol{primitive.Symbol("string")}})
 	env.Set("file:lines", &primitive.Procedure{F: fileLinesFn, Help: helpMap["file:lines"], Args: []primitive.Symbol{primitive.Symbol("path")}})
 	env.Set("file:read", &primitive.Procedure{F: fileReadFn, Help: helpMap["file:read"], Args: []primitive.Symbol{primitive.Symbol("path")}})
 	env.Set("file:stat", &primitive.Procedure{F: fileStatFn, Help: helpMap["file:stat"], Args: []primitive.Symbol{primitive.Symbol("path")}})
@@ -506,6 +507,33 @@ func expandStr(input string) string {
 	}
 
 	return out
+}
+
+// explodeFn splits a string into a list of characters
+func explodeFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
+
+	// We only need a single argument
+	if len(args) != 1 {
+		return primitive.ArityError()
+	}
+
+	// Which is a string
+	str, ok := args[0].(primitive.String)
+	if !ok {
+		return primitive.Error("argument not a string")
+	}
+
+	// Split it
+	out := strings.Split(str.ToString(), "")
+
+	// return a list of characters
+	var c primitive.List
+
+	for _, x := range out {
+		c = append(c, primitive.Character(x))
+	}
+
+	return c
 }
 
 // expnFn implements "#"

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -1085,8 +1085,14 @@ func ordFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive
 		return primitive.ArityError()
 	}
 
-	if _, ok := args[0].(primitive.String); !ok {
-		return primitive.Error("argument not a string")
+	// We work on strings, or characters
+	switch args[0].Type() {
+	case "character":
+		// nop
+	case "string":
+		// nop
+	default:
+		return primitive.Error(fmt.Sprintf("argument not a character/string, got %v", args[0].Type()))
 	}
 
 	// We convert this to an array of runes because we

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -206,7 +206,7 @@ func chrFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive
 	i := args[0].(primitive.Number)
 	rune := rune(i)
 
-	return primitive.String(rune)
+	return primitive.Character(rune)
 }
 
 // consFn implements (cons).

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -102,6 +102,7 @@ func PopulateEnvironment(env *env.Environment) {
 	env.Set("arch", &primitive.Procedure{F: archFn, Help: helpMap["arch"]})
 	env.Set("car", &primitive.Procedure{F: carFn, Help: helpMap["car"], Args: []primitive.Symbol{primitive.Symbol("list")}})
 	env.Set("cdr", &primitive.Procedure{F: cdrFn, Help: helpMap["cdr"], Args: []primitive.Symbol{primitive.Symbol("list")}})
+	env.Set("char=", &primitive.Procedure{F: charEqualsFn, Help: helpMap["char="], Args: []primitive.Symbol{primitive.Symbol("a"), primitive.Symbol("b")}})
 	env.Set("chr", &primitive.Procedure{F: chrFn, Help: helpMap["chr"], Args: []primitive.Symbol{primitive.Symbol("num")}})
 	env.Set("cons", &primitive.Procedure{F: consFn, Help: helpMap["cons"], Args: []primitive.Symbol{primitive.Symbol("a"), primitive.Symbol("b")}})
 	env.Set("contains?", &primitive.Procedure{F: containsFn, Help: helpMap["contains?"], Args: []primitive.Symbol{primitive.Symbol("hash"), primitive.Symbol("key")}})
@@ -190,6 +191,49 @@ func cdrFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive
 		return lst[1:]
 	}
 	return primitive.Nil{}
+}
+
+// charEqualsFn implements "char="
+func charEqualsFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
+
+	// We need at least two arguments
+	if len(args) < 2 {
+		return primitive.ArityError()
+	}
+
+	// First argument must be a character
+	nA, ok := args[0].(primitive.Character)
+	if !ok {
+		return primitive.Error("argument was not a character")
+	}
+
+	// Now we'll loop over all other arguments
+	//
+	// If we got something that was NOT the same as our
+	// initial value we can terminate early but we don't
+	// because it is important to also report on failures to
+	// validate types - which we can't do if we bail.
+	//
+	ret := primitive.Bool(true)
+
+	for _, i := range args[1:] {
+
+		// check we have a character
+		nB, ok2 := i.(primitive.Character)
+
+		if !ok2 {
+			return primitive.Error("argument was not a character")
+		}
+
+		// Record our failure, but keep testing in case
+		// we have a type violation to report in a later
+		// argument.
+		if nB != nA {
+			ret = primitive.Bool(false)
+		}
+	}
+
+	return ret
 }
 
 // chrFn is the implementation of (chr ..)

--- a/builtins/builtins_test.go
+++ b/builtins/builtins_test.go
@@ -2345,7 +2345,7 @@ func TestOrd(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected error, got %v", out)
 	}
-	if !strings.Contains(string(e), "not a string") {
+	if !strings.Contains(string(e), "not a character/string") {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 

--- a/builtins/builtins_test.go
+++ b/builtins/builtins_test.go
@@ -280,6 +280,70 @@ func TestCharEquals(t *testing.T) {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 }
+
+// test char<
+func TestCharLt(t *testing.T) {
+
+	// No arguments
+	out := charLtFn(ENV, []primitive.Primitive{})
+
+	// Will lead to an error
+	e, ok := out.(primitive.Error)
+	if !ok {
+		t.Fatalf("expected error, got %v", out)
+	}
+	if e != primitive.ArityError() {
+		t.Fatalf("got error, but wrong one %v", out)
+	}
+
+	// Argument which isn't a character
+	out = charLtFn(ENV, []primitive.Primitive{
+		primitive.String("foo"),
+		primitive.String("foo"),
+	})
+
+	// Will lead to an error
+	e, ok = out.(primitive.Error)
+	if !ok {
+		t.Fatalf("expected error, got %v", out)
+	}
+	if !strings.Contains(string(e), "not a character") {
+		t.Fatalf("got error, but wrong one %v", out)
+	}
+
+	// Argument which isn't a character
+	out = charLtFn(ENV, []primitive.Primitive{
+		primitive.Character("a"),
+		primitive.String("foo"),
+	})
+
+	// Will lead to an error
+	e, ok = out.(primitive.Error)
+	if !ok {
+		t.Fatalf("expected error, got %v", out)
+	}
+	if !strings.Contains(string(e), "not a character") {
+		t.Fatalf("got error, but wrong one %v", out)
+	}
+
+	//
+	// Now a real one
+	//
+	out = charLtFn(ENV, []primitive.Primitive{
+		primitive.Character("a"),
+		primitive.Character("b"),
+	})
+
+	// Will work
+	n, ok2 := out.(primitive.Bool)
+	if !ok2 {
+		t.Fatalf("expected bool, got %v", out)
+	}
+	if n != true {
+		t.Fatalf("got wrong result")
+	}
+
+}
 func TestChr(t *testing.T) {
 
 	// no arguments

--- a/builtins/builtins_test.go
+++ b/builtins/builtins_test.go
@@ -190,14 +190,13 @@ func TestChr(t *testing.T) {
 		primitive.Number(42),
 	})
 
-	r, ok2 := val.(primitive.String)
+	r, ok2 := val.(primitive.Character)
 	if !ok2 {
-		t.Fatalf("expected string, got %v", val)
+		t.Fatalf("expected character, got %v", val)
 	}
 	if r.ToString() != "*" {
 		t.Fatalf("got wrong result %v", r)
 	}
-
 }
 
 func TestCons(t *testing.T) {

--- a/builtins/builtins_test.go
+++ b/builtins/builtins_test.go
@@ -157,6 +157,129 @@ func TestCdr(t *testing.T) {
 	}
 }
 
+// TestCharEquals tests "chare=" (character equality)
+func TestCharEquals(t *testing.T) {
+
+	// No arguments
+	out := charEqualsFn(ENV, []primitive.Primitive{})
+
+	// Will lead to an error
+	e, ok := out.(primitive.Error)
+	if !ok {
+		t.Fatalf("expected error, got %v", out)
+	}
+	if e != primitive.ArityError() {
+		t.Fatalf("got error, but wrong one %v", out)
+	}
+
+	// One bogus argument
+	out = charEqualsFn(ENV, []primitive.Primitive{
+		primitive.Number(33),
+		primitive.Character("a"),
+	})
+
+	// Will lead to an error
+	e, ok = out.(primitive.Error)
+	if !ok {
+		t.Fatalf("expected error, got %v", out)
+	}
+	if !strings.Contains(string(e), "was not a character") {
+		t.Fatalf("got error, but wrong one %v", out)
+	}
+
+	//
+	// Now a real one: equal
+	//
+	out = charEqualsFn(ENV, []primitive.Primitive{
+		primitive.Character("a"),
+		primitive.Character("a"),
+	})
+
+	// Will work
+	n, ok2 := out.(primitive.Bool)
+	if !ok2 {
+		t.Fatalf("expected bool, got %v", out)
+	}
+	if n != true {
+		t.Fatalf("got wrong result")
+	}
+
+	//
+	// Now a real one: equal - but multiple values
+	//
+	out = charEqualsFn(ENV, []primitive.Primitive{
+		primitive.Character("b"),
+		primitive.Character("b"),
+		primitive.Character("b"),
+		primitive.Character("b"),
+		primitive.Character("b"),
+		primitive.Character("b"),
+	})
+
+	// Will work
+	n, ok2 = out.(primitive.Bool)
+	if !ok2 {
+		t.Fatalf("expected bool, got %v", out)
+	}
+	if n != true {
+		t.Fatalf("got wrong result")
+	}
+
+	//
+	// Now a real one: unequal values
+	//
+	out = charEqualsFn(ENV, []primitive.Primitive{
+		primitive.Character("a"),
+		primitive.Character("b"),
+		primitive.Character("c"),
+		primitive.Character("d"),
+	})
+
+	// Will work
+	n, ok2 = out.(primitive.Bool)
+	if !ok2 {
+		t.Fatalf("expected bool, got %v", out)
+	}
+	if n != false {
+		t.Fatalf("got wrong result")
+	}
+
+	//
+	// Now with wrong types - last one is wrong
+	//
+	out = charEqualsFn(ENV, []primitive.Primitive{
+		primitive.Character("a"),
+		primitive.Character("b"),
+		primitive.Character("c"),
+		primitive.Character("d"),
+		primitive.String("e"),
+	})
+
+	e, ok = out.(primitive.Error)
+	if !ok {
+		t.Fatalf("expected error, got %v", out)
+	}
+	if !strings.Contains(string(e), "was not a character") {
+		t.Fatalf("got error, but wrong one '%v'", e)
+	}
+
+	//
+	// Now with wrong types
+	//
+	out = charEqualsFn(ENV, []primitive.Primitive{
+		primitive.Character("b"),
+		primitive.Number(9),
+	})
+
+	// Will report an error
+	e, ok = out.(primitive.Error)
+	if !ok {
+		t.Fatalf("expected error, got %v", out)
+	}
+	if !strings.Contains(string(e), "was not a character") {
+		t.Fatalf("got error, but wrong one %v", out)
+	}
+}
 func TestChr(t *testing.T) {
 
 	// no arguments

--- a/builtins/builtins_test.go
+++ b/builtins/builtins_test.go
@@ -994,6 +994,55 @@ func TestExpandString(t *testing.T) {
 	}
 }
 
+// TestExplode tests explode?
+func TestExplode(t *testing.T) {
+
+	// No arguments
+	out := explodeFn(ENV, []primitive.Primitive{})
+
+	// Will lead to an error
+	e, ok := out.(primitive.Error)
+	if !ok {
+		t.Fatalf("expected error, got %v", out)
+	}
+	if e != primitive.ArityError() {
+		t.Fatalf("got error, but wrong one %v", out)
+	}
+
+	// An argument that isn't a string
+	out = explodeFn(ENV, []primitive.Primitive{
+		primitive.Number(3),
+	})
+
+	// Will lead to an error
+	e, ok = out.(primitive.Error)
+	if !ok {
+		t.Fatalf("expected error, got %v", out)
+	}
+	if !strings.Contains(string(e), "not a string") {
+		t.Fatalf("got error, but wrong one %v", out)
+	}
+
+	//
+	// Now a proper string
+	//
+	out = explodeFn(ENV, []primitive.Primitive{
+		primitive.String("fooπs"),
+	})
+
+	// Will lead to a list
+	l, ok2 := out.(primitive.List)
+	if !ok2 {
+		t.Fatalf("expected list, got %v", out)
+	}
+	if len(l) != 5 {
+		t.Fatalf("split list had the wrong length:%v", l)
+	}
+	if l.ToString() != "(f o o π s)" {
+		t.Fatalf("got wrong result %v", out)
+	}
+}
+
 // TestExpn tests "#"
 func TestExpn(t *testing.T) {
 
@@ -2728,7 +2777,7 @@ func TestSplit(t *testing.T) {
 	// Now a proper split
 	//
 	out = splitFn(ENV, []primitive.Primitive{
-		primitive.String("foo"),
+		primitive.String("fooπx"),
 		primitive.String(""),
 	})
 
@@ -2737,7 +2786,10 @@ func TestSplit(t *testing.T) {
 	if !ok2 {
 		t.Fatalf("expected list, got %v", out)
 	}
-	if l.ToString() != "(f o o)" {
+	if len(l) != 5 {
+		t.Fatalf("wrong length for result %v", l)
+	}
+	if l.ToString() != "(f o o π x)" {
 		t.Fatalf("got wrong result %v", out)
 	}
 

--- a/builtins/help.txt
+++ b/builtins/help.txt
@@ -218,6 +218,7 @@ ord returns the ASCII code for the character provided as the first input.
 
 See also: chr
 Example: (ord "a") ; => 97
+Example: (ord \#*) ; => 42
 %%
 os
 

--- a/builtins/help.txt
+++ b/builtins/help.txt
@@ -104,6 +104,13 @@ exists? returns true if the specified path exists, regardless of the type of pat
 See also: directory? file?
 Example: (print (exists? "/etc"))
 %%
+explode
+
+explode converts the specified string into a list of characters.
+
+See also: join,split
+Example: (print (explode "foo bar"))
+%%
 file?
 
 file? returns true if the specified path exists, and is a file.
@@ -174,7 +181,9 @@ Example: (print (help print))
 %%
 join
 
-join returns a string formed by converting every element of the supplied list into a string and concatenating them.
+join returns a string formed by converting every element of the supplied list into a string and concatenating the results.
+
+See also: explode, split
 %%
 keys
 
@@ -274,7 +283,7 @@ split
 
 split accepts two string parameters, and splits the first string by the term specified as the second argument, returning a list of the results.
 
-See also: join
+See also: explode, join
 Example: (split "steve" "e") ; => ("st" "v")
 Example: (split "steve" "")  ; => ("s" "t" "e" "v" "e")
 %%

--- a/builtins/help.txt
+++ b/builtins/help.txt
@@ -30,7 +30,7 @@ returns true if the numerical values supplied are all equal to each other.
 Note that multiple values may be specified, so it is possible to compare
 three, or more, values as per the second example below.
 
-See also: eq
+See also: char=, eq
 Example : (print (= 3 a))
 Example : (print (= 3 a b))
 %%
@@ -48,6 +48,12 @@ car returns the first item from the specified list.
 %%
 cdr
 cdr returns all items from the specified list, except the first.
+%%
+char=
+
+char= returns true if the supplied parameters were characters, and were equal.
+
+See also: =
 %%
 chr
 chr returns a string containing the single character who's ASCII code was provided.

--- a/builtins/help.txt
+++ b/builtins/help.txt
@@ -53,7 +53,13 @@ char=
 
 char= returns true if the supplied parameters were characters, and were equal.
 
-See also: =
+See also: = char<
+%%
+char<
+
+char< returns true if the first character is "less than" the second character.
+
+See also: < char=
 %%
 chr
 chr returns a string containing the single character who's ASCII code was provided.

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -50,24 +50,29 @@ func New(src string) *Eval {
 		symbols: make(map[string]primitive.Primitive),
 	}
 
-	// Setup the default symbols
-	t := primitive.Bool(true)
-	f := primitive.Bool(false)
-	n := primitive.Nil{}
+	// Setup the default symbol-table entries
 
-	// Save them in our symbol-table
-	e.symbols["#f"] = f
+	// true
+	t := primitive.Bool(true)
 	e.symbols["#t"] = t
-	e.symbols["false"] = f
-	e.symbols["nil"] = n
 	e.symbols["true"] = t
 
-	// character literals
+	// false
+	f := primitive.Bool(false)
+	e.symbols["#f"] = f
+	e.symbols["false"] = f
+
+	// nil
+	n := primitive.Nil{}
+	e.symbols["nil"] = n
+
+	// character literals - escaped characters
 	e.symbols["#\\\\a"] = primitive.Character("\a")
 	e.symbols["#\\\\b"] = primitive.Character("\b")
-	e.symbols["#\\\\t"] = primitive.Character("\t")
+	e.symbols["#\\\\f"] = primitive.Character("\f")
 	e.symbols["#\\\\n"] = primitive.Character("\n")
 	e.symbols["#\\\\r"] = primitive.Character("\r")
+	e.symbols["#\\\\t"] = primitive.Character("\t")
 
 	// tokenize our input program into a series of terms
 	e.tokenize(src)

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -36,6 +36,11 @@ func TestEvaluate(t *testing.T) {
 		{"#f", "#f"},
 		{"false", "#f"},
 
+		// character literals
+		{"#\\\\n", "\n"},
+		{"#\\a", "a"},
+		{"#\\AB", "ERROR{invalid character literal: AB}"},
+
 		// literals
 		{":foo", ":foo"},
 

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -123,6 +123,7 @@ func FuzzYAL(f *testing.F) {
 		"expected a function body",
 		"expected a list",
 		"expected a symbol",
+		"invalid character literal",
 		"is not a symbol",
 		"must have even length",
 		"not a function",

--- a/primitive/character.go
+++ b/primitive/character.go
@@ -1,0 +1,14 @@
+package primitive
+
+// Character holds a string value.
+type Character string
+
+// ToString converts this object to a string.
+func (c Character) ToString() string {
+	return string(c)
+}
+
+// Type returns the type of this primitive object.
+func (c Character) Type() string {
+	return "character"
+}

--- a/primitive/primitive_test.go
+++ b/primitive/primitive_test.go
@@ -21,6 +21,22 @@ func TestBool(t *testing.T) {
 	}
 }
 
+func TestCharacter(t *testing.T) {
+
+	nl := Character("\n")
+	ok := Character("o")
+
+	if nl.Type() != "character" {
+		t.Fatalf("wrong type")
+	}
+	if nl.ToString() != "\n" {
+		t.Fatalf("char->String had wrong result")
+	}
+	if ok.ToString() != "o" {
+		t.Fatalf("char->String had wrong result")
+	}
+}
+
 func TestError(t *testing.T) {
 
 	error := Error("no-cheese")

--- a/stdlib/stdlib/comparisons.lisp
+++ b/stdlib/stdlib/comparisons.lisp
@@ -1,7 +1,9 @@
-;;; comparisons.lisp - Numerical and integer comparisons
+;;; comparisons.lisp - boolean, character, and numerical comparison functions.
 
-;; We've defined "<" in natively, in golang.  We can
-;; define the other relational comparisons in terms of that.
+
+;; We've defined "<" in natively, in golang.
+;;
+;; We can define the other numerical relational comparisons in terms of that.
 (set! >  (fn* (a b)
               "Return true if a is greater than b."
               (< b a)))
@@ -12,6 +14,21 @@
 (set! <= (fn* (a b)
               "Return true if a is less than, or equal to, b."
               (! (> a b))))
+
+
+;; We've defined "char<" in natively, in golang.
+;;
+;; We can define the other relational comparisons in terms of that.
+(set! char>  (fn* (a b)
+              "Return true if a is greater than b."
+              (char< b a)))
+
+(set! char>= (fn* (a b)
+              "Return true if a is greater than, or equal to b."
+              (! (char< a b))))
+(set! char<= (fn* (a b)
+              "Return true if a is less than, or equal to, b."
+              (! (char> a b))))
 
 
 ;;

--- a/stdlib/stdlib/random.lisp
+++ b/stdlib/stdlib/random.lisp
@@ -6,9 +6,9 @@
                        "Return a random character by default from the set a-z.
 
 If an optional string is provided it will be used as a list of characters to choose from."
-                       (let* (chars (split "abcdefghijklmnopqrstuvwxyz" ""))
+                       (let* (chars (explode "abcdefghijklmnopqrstuvwxyz"))
                          (if (list? x)
-                             (set! chars (split (car x) "")))
+                             (set! chars (explode (car x))))
                          (random:item chars))))
 
 ;; random list item

--- a/stdlib/stdlib/type-checks.lisp
+++ b/stdlib/stdlib/type-checks.lisp
@@ -37,6 +37,10 @@
                      "Returns true if the argument specified is a string."
                      (eq (type x) "string")))
 
+(set! character?   (fn* (x)
+                     "Returns true if the argument specified is a character."
+                     (eq (type x) "character")))
+
 (set! symbol?   (fn* (x)
                      "Returns true if the argument specified is a symbol."
                      (eq (type x) "symbol")))

--- a/testdata/fuzz/FuzzYAL/4f511a4c208477912373b75d1f91fc8a51608750f1f25d0442545511336fac86
+++ b/testdata/fuzz/FuzzYAL/4f511a4c208477912373b75d1f91fc8a51608750f1f25d0442545511336fac86
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("#\\")


### PR DESCRIPTION
Once complete this pull-request will close #64, by supporting character literals.

Character literals look like this:

* `#\a`  -> "a"
* `#\X`  -> "X"
* `#\\n`  -> "\n"
* `#\\r`  -> "\r"
* `#\\t`  -> "\t"

No other escape sequences are supported than "\n", "\r", or "\t".

TODO:

* [x] Improve our escape-handling
  * A hard-coded list, but errors are immediately apparent, and adding new ones is easy.
* [x] Add test cases
* [x] Look at which builtin-functions should be added.
  * Perform the necessary additions.
* [x] Look at which builtin-functions should be changed.
  * Perform the necessary changes.