### PR TITLE
Allow the use of real/typed format strings

### DIFF
--- a/args.lisp
+++ b/args.lisp
@@ -6,7 +6,7 @@
 ;;
 
 ;; Show the count.
-(print "I received %s command-line arguments." (length os.args))
+(print "I received %d command-line arguments." (length os.args))
 
 ;; Show the actual arguments
 (print "Args: %s" os.args)

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -237,7 +237,6 @@ func charEqualsFn(env *env.Environment, args []primitive.Primitive) primitive.Pr
 	return ret
 }
 
-
 // charLtFn implements (char<)
 func charLtFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
 	if len(args) != 2 {
@@ -249,7 +248,7 @@ func charLtFn(env *env.Environment, args []primitive.Primitive) primitive.Primit
 		return primitive.Error("argument not a character")
 	}
 
-	b, ok2 := args[1].(primitive.Character);
+	b, ok2 := args[1].(primitive.Character)
 	if !ok2 {
 		return primitive.Error("argument not a character")
 	}
@@ -1256,7 +1255,15 @@ func printFn(env *env.Environment, args []primitive.Primitive) primitive.Primiti
 		if i == 0 {
 			continue
 		}
-		parm = append(parm, a.ToString())
+
+		// If we can use ToNative then do that,
+		// otherwise fall back to outputting a string.
+		native, ok := a.(primitive.ToNative)
+		if ok {
+			parm = append(parm, native.ToInterface())
+		} else {
+			parm = append(parm, a.ToString())
+		}
 	}
 
 	out := fmt.Sprintf(frmt, parm...)

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -1251,10 +1251,7 @@ func printFn(env *env.Environment, args []primitive.Primitive) primitive.Primiti
 	frmt := expandStr(args[0].ToString())
 	parm := []any{}
 
-	for i, a := range args {
-		if i == 0 {
-			continue
-		}
+	for _, a := range args[1:] {
 
 		// If we can use ToNative then do that,
 		// otherwise fall back to outputting a string.
@@ -1432,11 +1429,16 @@ func sprintfFn(env *env.Environment, args []primitive.Primitive) primitive.Primi
 	frmt := expandStr(args[0].ToString())
 	parm := []any{}
 
-	for i, a := range args {
-		if i == 0 {
-			continue
+	for _, a := range args[1:] {
+
+		// If we can use ToNative then do that,
+		// otherwise fall back to outputting a string.
+		native, ok := a.(primitive.ToNative)
+		if ok {
+			parm = append(parm, native.ToInterface())
+		} else {
+			parm = append(parm, a.ToString())
 		}
-		parm = append(parm, a.ToString())
 	}
 
 	out := fmt.Sprintf(frmt, parm...)

--- a/builtins/builtins_test.go
+++ b/builtins/builtins_test.go
@@ -2718,17 +2718,35 @@ func TestPrint(t *testing.T) {
 
 	// Two argument
 	out = printFn(ENV, []primitive.Primitive{
-		primitive.String("Hello %s!"),
-		primitive.String("Steve"),
+		primitive.String("Hello %d!"),
+		primitive.Number(3),
 	})
 
 	e2, ok2 = out.(primitive.String)
 	if !ok2 {
 		t.Fatalf("expected string, got %v", out)
 	}
-	if e2 != "Hello Steve!" {
-		t.Fatalf("got error, but wrong one %v", e2)
+	if e2 != "Hello 3!" {
+		t.Fatalf("got string, but wrong one %v", e2)
 	}
+
+	// Two argument with a type that can't be native-converated
+	out = printFn(ENV, []primitive.Primitive{
+		primitive.String("Hello %s!"),
+		primitive.List{
+			primitive.Number(3),
+			primitive.Number(4),
+		},
+	})
+
+	e2, ok2 = out.(primitive.String)
+	if !ok2 {
+		t.Fatalf("expected string, got %v", out)
+	}
+	if e2 != "Hello (3 4)!" {
+		t.Fatalf("got string, but wrong one %v", e2)
+	}
+
 }
 
 // TestRandom tests (random)
@@ -3007,6 +3025,20 @@ func TestSprintf(t *testing.T) {
 	}
 	if e2 != "Hello\t\"world\"\n\r!" {
 		t.Fatalf("got wrong result %v", e2)
+	}
+
+	// Two arguments with a native mapping
+	out = sprintfFn(ENV, []primitive.Primitive{
+		primitive.String("Hello %d!"),
+		primitive.Number(3),
+	})
+
+	e2, ok2 = out.(primitive.String)
+	if !ok2 {
+		t.Fatalf("expected string, got %v", out)
+	}
+	if e2 != "Hello 3!" {
+		t.Fatalf("got string, but wrong one %v", e2)
 	}
 }
 

--- a/builtins/help.txt
+++ b/builtins/help.txt
@@ -252,6 +252,14 @@ print
 
 print is used to output text to the console.  It can be called with either an object/string to print, or a format-string and list of parameters.
 
+When a format string is used it can contain the following strings:
+
+%c -> output a character value.
+%d -> output an integer.
+%f -> output a floating-point number.
+%s -> output a string.
+%t -> output a boolean value.
+
 See also: sprintf
 Example: (print "Hello, world")
 Example: (print "Hello user %s you are %d" (getenv "USER") 32)
@@ -302,6 +310,14 @@ Example: (split "steve" "")  ; => ("s" "t" "e" "v" "e")
 sprintf
 
 sprintf allows formating values with a simple format-string.
+
+When a format string is used it can contain the following strings:
+
+%c -> output a character value.
+%d -> output an integer.
+%f -> output a floating-point number.
+%s -> output a string.
+%t -> output a boolean value.
 
 See also: print
 Example: (sprintf "Today is %s" (weekday))

--- a/fibonacci.lisp
+++ b/fibonacci.lisp
@@ -20,10 +20,10 @@
 (set! add-numeric-suffix (fn* (n)
                               "Add a trailing suffix to make a number readable."
                               (cond
-                                (match "(^|[^1]+)1$" n) (sprintf "%sst" n)
-                                (match "(^|[^1]+)2$" n) (sprintf "%snd" n)
-                                (match "(^|[^1]+)3$" n) (sprintf "%srd" n)
-                                true  (sprintf "%sth" n)
+                                (match "(^|[^1]+)1$" n) (sprintf "%dst" n)
+                                (match "(^|[^1]+)2$" n) (sprintf "%dnd" n)
+                                (match "(^|[^1]+)3$" n) (sprintf "%drd" n)
+                                true  (sprintf "%dth" n)
                                 )))
 
 ;; Fibonacci function
@@ -37,5 +37,5 @@
 ;; Now call our function in a loop, twenty times.
 (let* (n 1)
   (while (<= n 25)
-    (print "%s fibonacci number is %s" (add-numeric-suffix n) (fibonacci n))
+    (print "%s fibonacci number is %d" (add-numeric-suffix n) (fibonacci n))
     (set! n (+ n 1) true)))

--- a/fizzbuzz.lisp
+++ b/fizzbuzz.lisp
@@ -14,7 +14,7 @@ and 'fizzbuzz' when divisible by both."
                             (= 0 (% n 15)) "fizzbuzz"
                             (= 0 (% n 3))  "fizz"
                             (= 0 (% n 5))  "buzz"
-                            true n) )))
+                            true (str n)) )))
 
 
 ;; As you can see the function above contains some help-text, or overview.

--- a/hash.lisp
+++ b/hash.lisp
@@ -22,7 +22,7 @@
 
 ;; This function is used as a callback by apply-hash.
 (set! hash-element (fn* (key val)
-   (print "KEY:%s VAL:%s" key val)))
+   (print "KEY:%s VAL:%s" key (str val))))
 
 ;; The `apply-hash` function will trigger a callback for each key and value
 ;; within a hash.

--- a/primitive/bool.go
+++ b/primitive/bool.go
@@ -5,7 +5,7 @@ type Bool bool
 
 // ToInterface converts this object to a golang value
 func (b Bool) ToInterface() any {
-	return b
+	return bool(b)
 }
 
 // ToString converts this object to a string.

--- a/primitive/bool.go
+++ b/primitive/bool.go
@@ -3,6 +3,11 @@ package primitive
 // Bool is our wrapping of bool
 type Bool bool
 
+// ToInterface converts this object to a golang value
+func (b Bool) ToInterface() any {
+	return b
+}
+
 // ToString converts this object to a string.
 func (b Bool) ToString() string {
 	if b {

--- a/primitive/character.go
+++ b/primitive/character.go
@@ -3,6 +3,14 @@ package primitive
 // Character holds a string value.
 type Character string
 
+// ToInterface converts this object to a golang value
+func (c Character) ToInterface() any {
+	if len(c) > 0 {
+		return c[0]
+	}
+	return ""
+}
+
 // ToString converts this object to a string.
 func (c Character) ToString() string {
 	return string(c)

--- a/primitive/error.go
+++ b/primitive/error.go
@@ -1,7 +1,14 @@
 package primitive
 
+import "fmt"
+
 // Error holds an error message.
 type Error string
+
+// ToInterface converts this object to a golang value
+func (e Error) ToInterface() any {
+	return fmt.Errorf(string(e))
+}
 
 // ToString converts this object to a string.
 func (e Error) ToString() string {

--- a/primitive/nil.go
+++ b/primitive/nil.go
@@ -3,6 +3,11 @@ package primitive
 // Nil type holds the undefined value
 type Nil struct{}
 
+// ToInterface converts this object to a golang value
+func (n Nil) ToInterface() any {
+	return nil
+}
+
 // ToString converts this object to a string.
 func (n Nil) ToString() string {
 	return "nil"

--- a/primitive/number.go
+++ b/primitive/number.go
@@ -7,6 +7,18 @@ import (
 // Number type holds numbers.
 type Number float64
 
+// ToInterface converts this object to a golang value
+func (n Number) ToInterface() any {
+
+	// int?
+	if float64(n) == float64(int(n)) {
+		return int(n)
+	}
+
+	// float
+	return float64(n)
+}
+
 // ToString converts this object to a string.
 func (n Number) ToString() string {
 

--- a/primitive/primitive.go
+++ b/primitive/primitive.go
@@ -12,6 +12,17 @@ type Primitive interface {
 	Type() string
 }
 
+// ToNative is an optional interface that some of our primitive
+// types might choose to implement.
+//
+// If available this allows a YAL object to be converted to a
+// suitable Golang equivalent type/value.
+type ToNative interface {
+
+	// ToInterface converts to a native golang type.
+	ToInterface() interface{}
+}
+
 // IsNil tests whether an expression is nil.
 func IsNil(e Primitive) bool {
 	var n Nil

--- a/primitive/procedure.go
+++ b/primitive/procedure.go
@@ -34,6 +34,11 @@ type Procedure struct {
 	Macro bool
 }
 
+// ToInterface converts this object to a golang value
+func (p *Procedure) ToInterface() any {
+	return p.ToString()
+}
+
 // ToString converts this object to a string.
 func (p *Procedure) ToString() string {
 	if p.F != nil {

--- a/primitive/procedure.go
+++ b/primitive/procedure.go
@@ -34,11 +34,6 @@ type Procedure struct {
 	Macro bool
 }
 
-// ToInterface converts this object to a golang value
-func (p *Procedure) ToInterface() any {
-	return p.ToString()
-}
-
 // ToString converts this object to a string.
 func (p *Procedure) ToString() string {
 	if p.F != nil {

--- a/primitive/symbol.go
+++ b/primitive/symbol.go
@@ -3,6 +3,11 @@ package primitive
 // Symbol is the type for our symbols.
 type Symbol string
 
+// ToInterface converts this object to a golang value
+func (s Symbol) ToInterface() any {
+	return s
+}
+
 // ToString converts this object to a string.
 func (s Symbol) ToString() string {
 	return string(s)

--- a/primitive/symbol.go
+++ b/primitive/symbol.go
@@ -5,7 +5,7 @@ type Symbol string
 
 // ToInterface converts this object to a golang value
 func (s Symbol) ToInterface() any {
-	return s
+	return s.ToString()
 }
 
 // ToString converts this object to a string.

--- a/stdlib/stdlib/time.lisp
+++ b/stdlib/stdlib/time.lisp
@@ -8,32 +8,33 @@
 ;; parts of the time, as well as some aliases for ease of typing.
 
 (set! time:hour (fn* ()
-                "Return the current hour, as an integer."
-                (nth (time) 0)))
+                     "Return the current hour, as an integer."
+                     (nth (time) 0)))
 
 (set! time:minute (fn* ()
-                  "Return the current minute, as an integer."
-                  (nth (time) 1)))
+                       "Return the current minute, as an integer."
+                       (nth (time) 1)))
 
 (set! time:second (fn* ()
-                  "Return the current seconds, as an integer."
-                  (nth (time) 2)))
+                       "Return the current seconds, as an integer."
+                       (nth (time) 2)))
 
 ;; define legacy aliases
-(alias hour time:hour)
-(alias minute time:minute)
-(alias second time:second)
+(alias hour time:hour
+       minute time:minute
+       second time:second)
 
-(set! zero-pad-single-number (fn* (num)
-                                  "Prefix the given number with zero, if the number is less than ten.
+(set! zero-pad-single-number (fn* (num:number)
+                                  "Return the given number, padded to two digits, as a string.
+i.e. Add a '0' prefix to the specified number, for values less than ten.
 
 This is designed to pad the hours, minutes, and seconds in (hms)."
                                   (if (< num 10)
-                                      (sprintf "0%s" num)
-                                    num)))
+                                      (sprintf "0%d" num)
+                                    (str num))))
 
 (set! time:hms (fn* ()
-               "Return the current time, formatted as 'HH:MM:SS', as a string."
+               "Return the current time as a string, formatted as 'HH:MM:SS'."
                (sprintf "%s:%s:%s"
                         (zero-pad-single-number (hour))
                         (zero-pad-single-number (minute))

--- a/test.lisp
+++ b/test.lisp
@@ -18,7 +18,7 @@
 ;; Use our "repeat" function, from the standard library, to run a block
 ;; N/10 times.  The number of the attempt is given as a parameter.
 ;;
-(repeat 10 (lambda (n) (print "I'm in a loop %s" n)))
+(repeat 10 (lambda (n) (print "I'm in a loop %d" n)))
 
 ;;
 ;; Use our "while" function, from the standard library, to run a block
@@ -27,7 +27,7 @@
 (let* (a 5)
   (while (> a 0)
     (do
-     (print "(while) loop - iteration %s" a)
+     (print "(while) loop - iteration %d" a)
      (set! a (- a 1) true))))
 
 
@@ -55,7 +55,7 @@ it took to execute.  Return that time, in ms."
 ;; `now` function which times how long it took.
 (apply (list 1 10 100 1000 10000 50000 100000)
        (lambda (x)
-         (print "Calculating %s factorial took %sms"
+         (print "Calculating %d factorial took %dms"
            x
            (benchmark (lambda () (fact x))))))
 
@@ -69,9 +69,9 @@ it took to execute.  Return that time, in ms."
 ;; Define a variable "foo => 0"
 ;; but then change it, and show that result
 (let* (foo 0)
-  (print "foo is set to %s" foo)
+  (print "foo is set to %d" foo)
   (set! foo 3)
-  (print "foo is now set to %s" foo))
+  (print "foo is now set to %d" foo))
 
 ;;Now we're outside the scope of the `let` so `foo` is nil
 (if foo
@@ -81,7 +81,7 @@ it took to execute.  Return that time, in ms."
 
 ;; Define another function, and invoke it
 (set! sum2 (fn* (n acc) (if (= n 0) acc (sum2 (- n 1) (+ n acc)))))
-(print "Sum of 1-100: %s" (sum2 100 0))
+(print "Sum of 1-100: %d" (sum2 100 0))
 
 ;; Now create a utility function to square a number
 (set! sq (fn* (x) (* x x)))
@@ -90,21 +90,21 @@ it took to execute.  Return that time, in ms."
 ;; Awesome!  Much Wow!
 (apply (nat 10)
       (lambda (x)
-        (print "%s\tsquared is %s" x (sq x))))
+        (print "%d\tsquared is %d" x (sq x))))
 
 ;; Test our some of our earlier functions against a range of numbers
 (apply (list -2 -1 0 1 2 3 4 5)
   (lambda (x)
     (do
-      (if (neg? x)  (print "%s is negative" x))
-      (if (zero? x) (print "%s is ZERO"     x))
-      (if (even? x) (print "%s is EVEN"     x))
-      (if (odd? x)  (print "%s is ODD"      x)))))
+      (if (neg? x)  (print "%d is negative" x))
+      (if (zero? x) (print "%d is ZERO"     x))
+      (if (even? x) (print "%d is EVEN"     x))
+      (if (odd? x)  (print "%d is ODD"      x)))))
 
 ;; Test that we can get the correct type of each of our primitives
 (apply (list 1 "steve" (list 1 2 3) true #t false #f nil boolean? print)
   (lambda (x)
-    (print "'%s' has type '%s'" x (type x))))
+    (print "'%s' has type '%s'" (str x) (type x))))
 
 
 ;;
@@ -123,11 +123,11 @@ it took to execute.  Return that time, in ms."
 ;;
 (let* (vals '(32 92 109 903 31 3 -93 -31 -17 -3))
   (print "Working with the list: %s " vals)
-  (print "\tBiggest item is %s"       (max vals))
-  (print "\tSmallest item is %s"      (min vals))
+  (print "\tBiggest item is %d"       (max vals))
+  (print "\tSmallest item is %d"      (min vals))
   (print "\tReversed list is %s "     (reverse vals))
   (print "\tSorted list is %s "       (sort vals))
-  (print "\tFirst item is %s "        (first vals))
+  (print "\tFirst item is %d "        (first vals))
   (print "\tRemaining items %s "      (rest vals)))
 
 
@@ -175,21 +175,21 @@ it took to execute.  Return that time, in ms."
 
 ;; We have a built-in eval function, which operates upon symbols, or strings.
 (set! e "(+ 3 4)")
-(print "Eval of '%s' resulted in %s" e (eval e))
-(print "Eval of '%s' resulted in %s" "(+ 40 2)" (eval "(+ 40 2)"))
+(print "Eval of '%s' resulted in %d" e (eval e))
+(print "Eval of '%s' resulted in %d" "(+ 40 2)" (eval "(+ 40 2)"))
 
 ;; Simple test of `cond`
 (set! a 6)
 (cond
     (> a 20) (print "A > 20")
     (> a 15) (print "A > 15")
-    true     (print "A is %s" a)
+    true     (print "A is %d" a)
 )
 
 ;;
 ;; Trivial Read/Eval pair
 ;;
-(print "The answer to life, the universe, and everything is %s!\n"
+(print "The answer to life, the universe, and everything is %d!\n"
   (eval (read "(* 6 7)")))
 
 ;; Upper-case and lower-casing of strings

--- a/time.lisp
+++ b/time.lisp
@@ -10,9 +10,9 @@
 ;; made available by helper-functions defined in our standard-library.
 ;;
 
-(print "The year is %s" (date:year))
-(print "The date is %s/%s/%s" (date:day) (date:month) (date:year))
-(print "The time is %s (%s seconds past the epoch)" (time:hms) (now))
+(print "The year is %d" (date:year))
+(print "The date is %d/%d/%d" (date:day) (date:month) (date:year))
+(print "The time is %s (%d seconds past the epoch)" (time:hms) (now))
 (print "Today is a %s" (date:weekday))
 
 (print "Date as a list %s" (date))


### PR DESCRIPTION
Once complete this pull-request will close #66, by allowing ("forcing") the use of real/typed format strings.

Currently we allow the user to use a real/typed format string to the `print` primitive, for example:

```sh
$ ./yal -e '(print "%s:%d:% .4f %s %t %c" "steve" 3 (/ 1 3) (list 1 2 3 4) false #\#)'
steve:3: 0.3333 (1 2 3 4) false #
```

Here we see the following format-strings:

* %s -> string
* %d -> decimal
* %f -> float
* %t -> boolean
* %c -> character

This is achieved via the use of an (optional) interface, instead of blindly casting things to a string.