### PR TITLE
Show aliased functions in the -h output.

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,6 +108,9 @@ func main() {
 		// We can only get help for functions which are present.
 		interpreter.Evaluate(environment)
 
+		// Show aliased functions, separately
+		aliased := interpreter.Aliased()
+
 		// Build up a list of all things known in the environment
 		keys := []string{}
 
@@ -142,6 +145,13 @@ func main() {
 
 			// Get the text
 			txt := prc.Help
+
+			// Is this an aliased function?
+			target, ok := aliased[key]
+			if ok {
+
+				txt = fmt.Sprintf("%s is an alias for %s.", key, target)
+			}
 
 			// Build up the arguments
 			args := ""


### PR DESCRIPTION
This pull request closes #68 by showing aliased functions specially in the output of yal when running with "-h".

For example:

```
$ ./yal  -h hms
hms
===
hms is an alias for time:hms.

time:hms
========
Return the current time as a string, formatted as 'HH:MM:SS'.

zero-pad-single-number (num:number)
===================================
Return the given number, padded to two digits, as a string.
i.e. Add a '0' prefix to the specified number, for values less than ten.

This is designed to pad the hours, minutes, and seconds in (hms).

```

When called via `(help)` everything works as-is, so there is no mention of the alias when this code runs:

```
(print (help hms))
```

(Because we don't have access to the name, to lookup the function, we just the result, when our arguments are expanded.)