### PR TITLE
Updated the main driver to simplify the code.

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -86,6 +86,20 @@ func New(src string) *Eval {
 	return e
 }
 
+// Execute will load the new code in the given src, and execute it
+// using the specified environment.
+//
+// This allows a single interpreter to be reused to execute multiple
+// expressions, with persistent state.
+func (ev *Eval) Execute(e *env.Environment, src string) primitive.Primitive {
+
+	// Reset our source
+	ev.tokenize(src)
+
+	// Now execute that source
+	return (ev.Evaluate(e))
+}
+
 // SetContext allows a context to be passed to the evaluator.
 //
 // The context allows you to setup a timeout/deadline for the
@@ -102,6 +116,11 @@ func (ev *Eval) Aliased() map[string]string {
 // tokenize splits the input string into tokens, via a horrific regular
 // expression which I don't understand!
 func (ev *Eval) tokenize(str string) {
+
+	// Reset our position
+	ev.offset = 0
+	ev.toks = []string{}
+
 	re := regexp.MustCompile(`[\s,]*(~@|[\[\]{}()'` + "`" +
 		`~^@]|"(?:\\.|[^\\"])*"|;.*|[^\s\[\]{}('"` + "`" +
 		`,;)]*)`)

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -37,6 +37,7 @@ func TestAliased(t *testing.T) {
 
 	// Get the aliases
 	a := l.Aliased()
+	size := len(a)
 
 	// Count of functions with a similar name
 	//
@@ -57,6 +58,28 @@ func TestAliased(t *testing.T) {
 
 	if similar == 0 {
 		t.Fatalf("found no similar aliases")
+	}
+
+	// Now execute another piece of code, in the same
+	// interpreter.
+	//
+	// We'll add a new alias and see if that gets found
+	out = l.Execute(env, "(do (alias testing +) (testing 30 12))")
+
+	if out.ToString() != "42" {
+		t.Fatalf("execution had unexpected result")
+	}
+
+	if l.aliases["testing"] != "+" {
+		t.Fatalf("testing alias wasn't set")
+	}
+
+	// Get the updated alias.
+	b := l.Aliased()
+
+	// Bigger, by one entry
+	if (size + 1) != len(b) {
+		t.Fatalf("failed to find newly added alias - old %v new %v", a, b)
 	}
 
 }


### PR DESCRIPTION
This closes #71, by simplifying the main.go driver.  We also added a means to execute code within the existing/persistent interpreter.

This had to be done to ensures we didn't reset our aliases, etc, between executions - partly because this is obvious, and partly anticipating #70.