### PR TITLE
70 repl

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,13 @@ Remember that if you're running a Mac you'll need to remove the quarantine flag 
 
 ## Usage
 
-Once installed there are two ways to execute code:
+Once installed there are three ways to execute code:
 
 * By specifying an expression to execute upon the command-line:
   * `yal -e '(print (os))'`
 * By passing the name of a file containing lisp code to read and execute:
   * `yal test.lisp`
+* By launching the interpreter with zero arguments, which will launch the interactive REPL mode.
 
 The yal interpreter allows (optional) documentation to be attached to functions, both those implemented in the core, and those which are added in lisp:
 

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -250,8 +251,39 @@ func main() {
 		os.Exit(0)
 	}
 
-	// No arguments
 	//
-	// TODO REPL
+	// No arguments mean this is our REPL
 	//
+	fmt.Printf("YAL version %s\n", version)
+	reader := bufio.NewReader(os.Stdin)
+
+	src := ""
+	for {
+		if src == "" {
+			fmt.Printf("\n> ")
+		}
+
+		line, _ := reader.ReadString('\n')
+		src += line
+		src = strings.TrimSpace(src)
+
+		open := strings.Count(src, "(")
+		close := strings.Count(src, ")")
+
+		if open < close {
+			fmt.Printf("Malformed expression: %v", src)
+			src = ""
+			continue
+		}
+		if open == close {
+
+			out := LISP.Execute(ENV, src)
+
+			// If the result wasn't nil then show it
+			if _, ok := out.(primitive.Nil); !ok {
+				fmt.Printf("%v\n", out)
+			}
+			src = ""
+		}
+	}
 }

--- a/main.go
+++ b/main.go
@@ -267,6 +267,11 @@ func main() {
 		src += line
 		src = strings.TrimSpace(src)
 
+		// Allow the user to exit
+		if src == "exit" || src == "quit" {
+			os.Exit(0)
+		}
+
 		open := strings.Count(src, "(")
 		close := strings.Count(src, ")")
 


### PR DESCRIPTION
Added a simple REPL mode, accessed when the user launches the driver with no arguments.

Enter `quit` or `exit` to exit - or press Ctrl-c.

This closes #70.