### PR TITLE
82 struct

### DIFF
--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -5,7 +5,63 @@
 
 # Brief Yal Introduction
 
-To set the contents of a variable use `set!`:
+Yal is a typical toy lisp with support for numbers, strings, characters, hashes and structures.
+
+
+## Primitive Types
+
+Primitive types work as you would expect:
+
+* Strings are just encoded literally, and escaped characters are honored:
+  * `(print "Hello, world\n")`
+* Numbers can be written as integers in decimal, binary, or hex.
+* Floating point numbers are also supported:
+  * `(print 3)`
+  * `(print 0xff)`
+  * `(print 0b1010)`
+  * `(print 3.4)`
+* Characters are written with a `#\` prefix.
+  * `(print #\*)`
+
+
+## Other Types
+
+We support hashes, which are key/value pairs, written between `{` and `}` pairs:
+
+```lisp
+(print { name "Steve" age (- 2022 1976) } )
+```
+
+Functions exist for getting/setting fields by name, and for iterating over keys, values, or key/value pairs.
+
+We also support structures, which are syntactical sugar for hashes, along with the autogeneration of some methods.
+
+To define a "person" with three fields you'd write:
+
+```lisp
+(struct person name age address)
+```
+
+Once this `struct` has been defined it can be populated via the constructor:
+
+```lisp
+(person "Steve" "18" "123 Fake Street")
+```
+
+The structure's fields can be accessed, and updated:
+
+```
+; Define "me" as a person with fields
+(set! me (person "Steve" "18" "123 Fake Street"))
+
+; Change the adddress
+(person.address me "999 Fake Lane")
+```
+
+
+## Variables
+
+To set the contents of a variable use `set!` which we saw above:
 
     (set! foo "bar")
 
@@ -27,6 +83,9 @@ form of `set!`:
       (set! global "updated" true)
       ;..
     )
+
+
+## Functions
 
 To define a function use `set!` with `fn*`:
 

--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -3,6 +3,7 @@
   * [Symbols](#symbols)
   * [Special Forms](#special-forms)
   * [Core Primitives](#core-primitives)
+  * [Structure Methods](#structure-methods)
   * [Standard Library](#standard-library)
 * [Type Checking](#type-checking)
 * [Testing](#testing)
@@ -14,7 +15,8 @@
 Here is a list of all the primitives which are available to yal users.
 
 Note that you might need to consult the source of the standard-library, or
-the help file, to see further details.  This is just intended as a summary.
+the help file, to see further details.  This document is primarily intended
+as a quick summary, and might lapse behind reality at times.
 
 
 ## Symbols
@@ -74,6 +76,8 @@ Special forms are things that are built into the core interpreter, and include:
   * Read a form from the specified string.
 * `set!`
   * Set the value of a variable.
+* `struct`
+  * Define a structure.
 * `symbol`
   * Create a new symbol from the given string.
 * `try`
@@ -219,6 +223,34 @@ Things you'll find here include:
 * `vals`
   * Return the values contained within the given hash.
   * Note that this returns things in the order of the sorted-keys.
+
+
+
+## Structure Methods
+
+A structure is a minimal wrapper over a hash, but when a structure is
+defined several methods are created.  Assuming a person-structure has
+been defined like so:
+
+```lisp
+(struct person name age address)
+```
+
+There is now a new structure, named `person` with three fields `name`, `age`, and `address` which can be instantiated.
+
+To help operate upon this structure several methods have also been created:
+
+* `(person "name" "age" "address")`
+  * Constructor method, which returns a new struct instance.
+  * If the number of arguments is less than the number of object-fields they will be left unset (i.e. nil).
+* `(person? obj)`
+  * Returns true if the given object is an instance of the person struct.
+* `(person.name obj [new-value])`
+  * Accessor/Mutator for the name-field in the given struct instance.
+* `(person.age obj [new-value])`
+  * Accessor/Mutator for the age-field in the given struct instance.
+* `(person.address obj [new-value])`
+  * Accessor/Mutator for the address-field in the given struct instance.
 
 
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
 
 * [A brief introduction to using this lisp](INTRODUCTION.md).
   * Getting started setting variables, defining functions, etc.
+  * This includes documentation on enhanced features such as
+    * Hashes.
+    * Structures.
 * [A list of primitives we have implemented](PRIMITIVES.md).
   * This describes the functions we support, whether implemented in lisp or golang.
   * For example `(car)`, `(cdr)`, `(file:lines)`, `(shell)`, etc.

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -870,7 +870,7 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 
 					// ensure that we have some fields that
 					// match those we expect.
-					if len(fields) != len(listArgs) {
+					if len(listArgs) > len(fields) {
 						return primitive.ArityError()
 					}
 
@@ -883,7 +883,11 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 
 					// Set the fields, ensuring we evaluate them
 					for i, name := range fields {
-						hash.Set(name, ev.eval(listArgs[i], e, expandMacro))
+						if i < len(listArgs) {
+							hash.Set(name, ev.eval(listArgs[i], e, expandMacro))
+						} else {
+							hash.Set(name, primitive.Nil{})
+						}
 					}
 					return hash
 				}

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -867,8 +867,8 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 					typeName := strings.TrimSuffix(thing.ToString(), "?")
 
 					// Does that represent a known-type?
-					_, ok := ev.structs[typeName]
-					if ok {
+					_, ok2 := ev.structs[typeName]
+					if ok2 {
 
 						// OK a type-check on a known struct
 						//

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -322,6 +322,15 @@ a
 		{"(let* (a 3 b))", "ERROR{list for (len*) must have even length, got [a 3 b]}"},
 		{"(let* (a 3 3 b))", "ERROR{binding name is not a symbol, got 3}"},
 
+		{"(struct foo bar)  (type (foo 3))", "struct-foo"},
+		{"(struct foo bar)  (foo 3 3)", primitive.ArityError().ToString()},
+		{"(struct foo bar)  (foo? nil)", "#f"},
+		{"(struct foo bar)  (foo? (foo 3))", "#t"},
+		{"(struct a name) (struct b name)  (a? (b 3))", "#f"},
+		{"(struct a name) (struct b name)  (b? (b 3))", "#t"},
+
+		{"(struct)", primitive.ArityError().ToString()},
+		{"(do (struct foo bar ) (foo?))", primitive.ArityError().ToString()},
 		{"(error )", primitive.ArityError().ToString()},
 		{"(quote )", primitive.ArityError().ToString()},
 		{"(quasiquote )", primitive.ArityError().ToString()},

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -266,6 +266,10 @@ a
 		// struct
 		{"(struct foo bar) (set! me (foo 3)) (foo.bar me)", "3"},
 		{"(struct foo bar) (set! me (foo 3)) (foo.bar me 32) (foo.bar me)", "32"},
+		{`(struct cat name age) (set! me (cat "meow" 3)) (cat.name me)`, "meow"},
+		{`(struct cat name age) (set! me (cat "meow")) (cat.name me)`, "meow"},
+		{`(struct cat name age) (set! me (cat "meow" 3)) (cat.age me)`, "3"},
+		{`(struct cat name age) (set! me (cat "meow")) (cat.age me)`, "nil"},
 
 		// maths
 		{"(+ 3 1)", "4"},

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -263,6 +263,10 @@ a
 		{"(cond false 7 (= 2 2) 8 \"else\" 9)", "8"},
 		{"(cond false 7 false 8 false 9)", "nil"},
 
+		// struct
+		{"(struct foo bar) (set! me (foo 3)) (foo.bar me)", "3"},
+		{"(struct foo bar) (set! me (foo 3)) (foo.bar me 32) (foo.bar me)", "32"},
+
 		// maths
 		{"(+ 3 1)", "4"},
 		{"(- 3 1)", "2"},

--- a/lisp-tests.lisp
+++ b/lisp-tests.lisp
@@ -359,6 +359,14 @@ If the name of the test is not unique then that will cause an error to be printe
 (deftest binary:1 (list (dec2bin 3) "11"))
 (deftest binary:2 (list (dec2bin 4) "100"))
 
+;; structures
+(deftest struct:1 (list (do (struct person name) (type (person "me")))
+                        "struct-person"))
+(deftest struct:2 (list (do (struct person name) (person? (person "me")))
+                        true))
+(deftest struct:3 (list (do (struct person name) (person.name (person "me")))
+                        "me"))
+
 
 ;;
 ;; Define a function to run all the tests, by iterating over the hash.

--- a/primitive/hash.go
+++ b/primitive/hash.go
@@ -1,8 +1,27 @@
 package primitive
 
+import "fmt"
+
 // Hash holds a collection of other types, indexed by string
 type Hash struct {
+
+	// Entries contains the key/value pairs this object holds.
 	Entries map[string]Primitive
+
+	// StructType contains the name of this struct, if it is being
+	// being used to implement a Struct, rather than a Hash
+	StructType string
+}
+
+// SetStruct marks this as a "struct" type instead of a "hash type",
+// when queried by lisp
+func (h *Hash) SetStruct(name string) {
+	h.StructType = name
+}
+
+// GetStruct returns the name of the structure this object contains, if any
+func (h *Hash) GetStruct() string {
+	return h.StructType
 }
 
 // Get returns the value of a given index
@@ -40,5 +59,8 @@ func (h Hash) ToString() string {
 
 // Type returns the type of this primitive object.
 func (h Hash) Type() string {
-	return "hash"
+	if h.StructType == "" {
+		return "hash"
+	}
+	return fmt.Sprintf("struct-%s", h.StructType)
 }

--- a/primitive/hash_test.go
+++ b/primitive/hash_test.go
@@ -27,3 +27,33 @@ func TestHash(t *testing.T) {
 		t.Fatalf("string value of hash was wrong")
 	}
 }
+
+func TestHashStruct(t *testing.T) {
+
+	// Create a hash
+	h := NewHash()
+
+	// mark it as a struct
+	h.SetStruct("pie")
+
+	out := h.Get("NAME")
+	_, ok := out.(Nil)
+	if !ok {
+		t.Fatalf("expected nil getting hash value that is absent")
+	}
+
+	h.Set("NAME", String("ME"))
+	valid := h.Get("NAME")
+	if valid.ToString() != "ME" {
+		t.Fatalf("got wrong value")
+	}
+
+	if h.Type() != "struct-pie" {
+		t.Fatalf("Wrong type for struct")
+	}
+
+	if h.GetStruct() != "pie" {
+		t.Fatalf("Wrong struct-type for struct")
+	}
+
+}


### PR DESCRIPTION
This pull-request contains a "struct" implementation, which currently allows structures to be defined - as a list of fields, and objects created assuming all fields are present.  One a struct has been created magical methods allow type-checking and field access/updates.
    
This will close #82, once complete.
    
Sample usage, which works with this pull-request:

```lisp

;; define a structure
(struct person name address)
(struct cat    name age)

;; create an instance of a person
(set! self (person "Steve Kemp" "My home address, Helsinki, Finland"))

;; create an instance of a cat
(set! kitty (cat "Meow" (- 2022 2018 )))

;; show the type of our object, and the fields
(print "The person struct.type is %s" (type self))
(print "The person struct.address contains:%s" (get self "address"))
(print "The person struct.name contains:%s" (get self "name"))

;; Type-checking should "just work"
(if (person? self)
    (print "self is a person")
  (print "self is NOT a person - bug"))

(if (cat? self)
    (print "A person cannot be a cat - bug"))

(if (cat? kitty)
    (print "We have a cat, aged %d" (get kitty "age")))

(print (cat.name kitty))
(cat.name kitty (join (list "My " "New" " " "Name")))
(print (cat.name kitty))

```

Here you'll notice that the struct is actually a hash, and we're merely setting the named fields as key/val pairs.
    
This is pretty smart, all we've really done is recorded the fields a structure should contain, and hooked into our execution to instantiate a new hash when we see a named structure - before falling back to invoking a command instead.
    
The bit that's missing?

* [X] We want to allow structs to be defined.
* [X] We want to allow structs to be instantiated.
* [X]  We want to have "type?" support.
* [x] We want to have field-accessors created.
* [x] We want to have field-mutators created.
* [x] Test cases.
* [x] Documentation.

Adding accessors was a little tricky, but we store the name of the faux method in a map with the appropriate field as the value.  This allows accesses to be found and updates to be made.

The biggest issue here is that we're doing extra checks on the "hot path", so the whole eval method is getting deeply complex and slower.  I think that needs to be spun out into a different issue.
