### PR TITLE
Simplify our eval() method.

### DIFF
--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -12,16 +12,18 @@ Yal is a typical toy lisp with support for numbers, strings, characters, hashes 
 
 Primitive types work as you would expect:
 
-* Strings are just encoded literally, and escaped characters are honored:
-  * `(print "Hello, world\n")`
-* Numbers can be written as integers in decimal, binary, or hex.
-* Floating point numbers are also supported:
+* Numbers can be written as integers in decimal, binary, or hex:
   * `(print 3)`
   * `(print 0xff)`
   * `(print 0b1010)`
+* Floating point numbers are also supported:
   * `(print 3.4)`
-* Characters are written with a `#\` prefix.
+* Strings are just encoded literally, and escaped characters are honored:
+  * `(print "Hello, world\n")`
+* Characters are written with a `#\` prefix:
   * `(print #\*)`
+* Lists are written using parenthesis to group them:
+  * `(print (list 1 2 3))`
 
 
 ## Other Types
@@ -32,9 +34,9 @@ We support hashes, which are key/value pairs, written between `{` and `}` pairs:
 (print { name "Steve" age (- 2022 1976) } )
 ```
 
-Functions exist for getting/setting fields by name, and for iterating over keys, values, or key/value pairs.
+Functions exist for getting/setting fields by name, and for iterating over the keys, values, or key/value pairs, contained in a given hash.
 
-We also support structures, which are syntactical sugar for hashes, along with the autogeneration of some methods.
+We also support structures, which are syntactical sugar for hashes, along with the autogeneration of some simple helper methods.
 
 To define a "person" with three fields you'd write:
 
@@ -48,14 +50,23 @@ Once this `struct` has been defined it can be populated via the constructor:
 (person "Steve" "18" "123 Fake Street")
 ```
 
-The structure's fields can be accessed, and updated:
+Values which are not supplied will default to `nil`:
+
+```lisp
+(person "Steve" "18")
+```
+
+The structure's fields can be accessed, and updated via generated methods, named after the type of the object, and the field involved:
 
 ```
-; Define "me" as a person with fields
+; Set the variable "me" to be a new instance of the person-structure.
 (set! me (person "Steve" "18" "123 Fake Street"))
 
 ; Change the adddress
 (person.address me "999 Fake Lane")
+
+; Confirm it worked
+(print (person.address me))
 ```
 
 

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -288,38 +288,23 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 		}
 
 		//
+		// Simple types return themselves literally.
+		//
+		// For example a string returns itself, as
+		// does a number, a boolean, or a hash.
+		//
+		// Lists are the things that are complex in
+		// lisp, as they represent function calls.
+		//
+		if exp.IsSimpleType() {
+			return exp
+		}
+
+		//
 		// Behaviour depends on the type of the primitive/expression
 		// we've been given to execute.
 		//
 		switch exp.(type) {
-
-		// Booleans return themselves
-		case primitive.Bool:
-			return exp
-
-		// Characters return themselves
-		case primitive.Character:
-			return exp
-
-		// Errors return themselves
-		case primitive.Error:
-			return exp
-
-		// Hashes return themselves
-		case primitive.Hash:
-			return exp
-
-		// Numbers return themselves
-		case primitive.Number:
-			return exp
-
-		// Nil returns itself
-		case primitive.Nil:
-			return exp
-
-		// Strings return themselves
-		case primitive.String:
-			return exp
 
 		// Symbols return the value they contain
 		case primitive.Symbol:

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -271,6 +271,10 @@ a
 		{`(struct cat name age) (set! me (cat "meow" 3)) (cat.age me)`, "3"},
 		{`(struct cat name age) (set! me (cat "meow")) (cat.age me)`, "nil"},
 
+		// struct - errors
+		{"(struct foo bar) (foo.bar 3)", "ERROR{expected a hash, got 3}"},
+		{`(struct cat age) (set! me (cat "meow")) (cat.age me 3 4)`, primitive.ArityError().ToString()},
+
 		// maths
 		{"(+ 3 1)", "4"},
 		{"(- 3 1)", "2"},

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -394,10 +394,10 @@ a
 		{"(try (/ 1 0) (catch x))", "ERROR{list should have three elements, got [catch x]}"},
 
 		// type failures
-		{input: "(define blah (lambda (a:list) (print a))) (blah 3)", output: "ERROR{type-validation failed: argument a to blah was supposed to be list, got number}"},
-		{input: "(define blah (lambda (a:string) (print a))) (blah 3)", output: "ERROR{type-validation failed: argument a to blah was supposed to be string, got number}"},
-		{input: "(define blah (lambda (a:number) (print a))) (blah '(3))", output: "ERROR{type-validation failed: argument a to blah was supposed to be number, got list}"},
-		{input: "(define blah (lambda (a:function) (print a))) (blah '(3))", output: "ERROR{type-validation failed: argument a to blah was supposed to be function, got list}"},
+		{input: "(define blah (lambda (a:list) (print a))) (blah 3)", output: "ERROR{TypeError - argument a to blah was supposed to be list, got number}"},
+		{input: "(define blah (lambda (a:string) (print a))) (blah 3)", output: "ERROR{TypeError - argument a to blah was supposed to be string, got number}"},
+		{input: "(define blah (lambda (a:number) (print a))) (blah '(3))", output: "ERROR{TypeError - argument a to blah was supposed to be number, got list}"},
+		{input: "(define blah (lambda (a:function) (print a))) (blah '(3))", output: "ERROR{TypeError - argument a to blah was supposed to be function, got list}"},
 		{input: "(define blah (lambda (a:any) (print a))) (blah '(3))", output: "(3)"},
 	}
 

--- a/eval/specials.go
+++ b/eval/specials.go
@@ -1,0 +1,240 @@
+// specials.go - Implementation of the special forms.
+
+package eval
+
+import (
+	"fmt"
+
+	"github.com/skx/yal/env"
+	"github.com/skx/yal/primitive"
+)
+
+// evalSpecialForm is invoked to execute one of our special forms.
+//
+// This is done to centralize the code, and also ensure that eval doesn't
+// get too dense.
+//
+// The return value from this function is "XX, BOOL".  If the boolean result
+// is true this function handled the call, otherwise it did not.
+//
+// This is required because special forms take precedence over other calls.
+func (ev *Eval) evalSpecialForm(name string, args []primitive.Primitive, e *env.Environment, expandMacro bool) (primitive.Primitive, bool) {
+
+	switch name {
+	case "alias":
+		// We need at least one pair.
+		if len(args) < 2 {
+			return primitive.ArityError(), true
+		}
+
+		if len(args)%2 != 0 {
+			return primitive.Error(fmt.Sprintf("(alias ..) must have an even length of arguments, got %v", args)), true
+		}
+
+		for i := 0; i < len(args); i += 2 {
+
+			// The key/val pair we're working with
+			new := args[i]
+			orig := args[i+1]
+
+			old, ok := e.Get(orig.ToString())
+			if ok {
+				e.Set(new.ToString(), old)
+
+				ev.aliases[new.ToString()] = orig.ToString()
+			}
+		}
+		return primitive.Nil{}, true
+
+	// (define
+	case "define", "def!":
+		if len(args) < 2 {
+			return primitive.ArityError(), true
+		}
+		symb, ok := args[0].(primitive.Symbol)
+		if ok {
+			val := ev.eval(args[1], e, expandMacro)
+			e.Set(string(symb), val)
+			return primitive.Nil{}, true
+		}
+		return primitive.Error(fmt.Sprintf("Expected a symbol, got %v", args[0])), true
+
+	// (defmacro!
+	case "defmacro!":
+		if len(args) < 2 {
+			return primitive.ArityError(), true
+		}
+
+		// name of macro
+		symb, ok := args[0].(primitive.Symbol)
+		if !ok {
+			return primitive.Error(fmt.Sprintf("Expected a symbol, got %v", args[0])), true
+		}
+
+		// macro body
+		val := ev.eval(args[1], e, expandMacro)
+
+		mac, ok2 := val.(*primitive.Procedure)
+		if !ok2 {
+			return primitive.Error(fmt.Sprintf("expected a function body for (defmacro..), got %v", val)), true
+		}
+
+		// this is now a macro
+		mac.Macro = true
+		e.Set(string(symb), mac)
+		return primitive.Nil{}, true
+
+	case "do":
+		var ret primitive.Primitive
+		for _, x := range args {
+			ret = ev.eval(x, e, expandMacro)
+		}
+		return ret, true
+
+	case "eval":
+		if len(args) != 1 {
+			return primitive.ArityError(), true
+		}
+
+		switch val := args[0].(type) {
+
+		// Evaluate
+		case primitive.List:
+			// Evaluate the list
+			res := ev.eval(args[0], e, expandMacro)
+
+			// Create a new evaluator with
+			// the result as a string
+			tmp := New(res.ToString())
+
+			// Ensure that we have a suitable
+			// child-environment.
+			nEnv := env.NewEnvironment(e)
+
+			// Now evaluate it.
+			return tmp.Evaluate(nEnv), true
+
+		// symbol solely so we can do env. lookup
+		case primitive.Symbol:
+			str, ok := e.Get(val.ToString())
+			if ok {
+				tmp := New(str.(primitive.Primitive).ToString())
+				nEnv := env.NewEnvironment(e)
+				return tmp.Evaluate(nEnv), true
+			}
+			return primitive.Nil{}, true
+
+		// string eval
+		case primitive.String:
+			tmp := New(string(val))
+			nEnv := env.NewEnvironment(e)
+			return tmp.Evaluate(nEnv), true
+
+		default:
+			return primitive.Error(fmt.Sprintf("unexpected type for eval %V.", args[0])), true
+		}
+
+	// (lambda
+	case "lambda", "fn*":
+		// ensure we have arguments
+		if len(args) != 2 && len(args) != 3 {
+			return primitive.ArityError(), true
+		}
+
+		// ensure that our arguments are a list
+		argMarkers, ok := args[0].(primitive.List)
+		if !ok {
+			return primitive.Error(fmt.Sprintf("expected a list for arguments, got %v", args[0])), true
+		}
+
+		// Collect arguments
+		arguments := []primitive.Symbol{}
+		for _, x := range argMarkers {
+
+			xs, ok := x.(primitive.Symbol)
+			if !ok {
+				return primitive.Error(fmt.Sprintf("expected a symbol for an argument, got %v", x)), true
+			}
+			arguments = append(arguments, xs)
+		}
+
+		body := args[1]
+		help := ""
+
+		// If there's an optional help string ..
+		if len(args) == 3 {
+			help = args[1].ToString()
+			body = args[2]
+		}
+
+		// This is a procedure, which will default
+		// to not being a macro.
+		//
+		// To make it a macro it should be set with
+		// "(defmacro!..)"
+		return &primitive.Procedure{
+			Args:  arguments,
+			Body:  body,
+			Env:   e,
+			Help:  help,
+			Macro: false,
+		}, true
+
+	// (quote ..)
+	case "quote":
+		if len(args) != 1 {
+			return primitive.ArityError(), true
+		}
+		return args[0], true
+
+	case "read":
+		if len(args) != 1 {
+			return primitive.ArityError(), true
+		}
+
+		arg := args[0].ToString()
+
+		// Create a new evaluator with the list
+		tmp := New(arg)
+
+		// Read an expression with it.
+		//
+		// Note here we just _read_ the expression,
+		// we don't evaluate it.
+		//
+		// So we don't need an environment, etc.
+		//
+		out, err := tmp.readExpression(e)
+		if err != nil {
+			return primitive.Error(fmt.Sprintf("failed to read %s:%s", arg, err.Error())), true
+		}
+
+		// Return it.
+		return out, true
+
+	// (set!
+	case "set!":
+		if len(args) < 2 {
+			return primitive.ArityError(), true
+		}
+
+		// Get the symbol we're gonna set
+		sym, ok := args[0].(primitive.Symbol)
+		if !ok {
+			return primitive.Error(fmt.Sprintf("tried to set a non-symbol %v", args[0])), true
+		}
+
+		// Get the value.
+		val := ev.eval(args[1], e, expandMacro)
+
+		// Now set, either locally or in the parent scope.
+		if len(args) == 3 {
+			e.SetOuter(string(sym), val)
+		} else {
+			e.Set(string(sym), val)
+		}
+		return primitive.Nil{}, true
+
+	}
+	return primitive.Nil{}, false
+}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -132,7 +132,7 @@ func FuzzYAL(f *testing.F) {
 		"not a number",
 		"not a string",
 		"recursion limit",
-		"type-validation failed",
+		"typeerror - ",
 		"unexpected type",
 	}
 

--- a/primitive/bool.go
+++ b/primitive/bool.go
@@ -3,6 +3,12 @@ package primitive
 // Bool is our wrapping of bool
 type Bool bool
 
+// IsSimpleType is used to denote whether this object
+// is self-evaluating.
+func (b Bool) IsSimpleType() bool {
+	return true
+}
+
 // ToInterface converts this object to a golang value
 func (b Bool) ToInterface() any {
 	return bool(b)

--- a/primitive/character.go
+++ b/primitive/character.go
@@ -3,6 +3,12 @@ package primitive
 // Character holds a string value.
 type Character string
 
+// IsSimpleType is used to denote whether this object
+// is self-evaluating.
+func (c Character) IsSimpleType() bool {
+	return true
+}
+
 // ToInterface converts this object to a golang value
 func (c Character) ToInterface() any {
 	if len(c) > 0 {

--- a/primitive/error.go
+++ b/primitive/error.go
@@ -11,6 +11,12 @@ func ArityError() Error {
 	return Error("ArityError - Unexpected argument count")
 }
 
+// TypeError is an error raised when a function is called with invalid
+// typed argument
+func TypeError(msg string) Error {
+	return Error("TypeError - " + msg)
+}
+
 // IsSimpleType is used to denote whether this object
 // is self-evaluating.
 func (e Error) IsSimpleType() bool {

--- a/primitive/error.go
+++ b/primitive/error.go
@@ -11,6 +11,12 @@ func ArityError() Error {
 	return Error("ArityError - Unexpected argument count")
 }
 
+// IsSimpleType is used to denote whether this object
+// is self-evaluating.
+func (e Error) IsSimpleType() bool {
+	return true
+}
+
 // ToInterface converts this object to a golang value
 func (e Error) ToInterface() any {
 	return fmt.Errorf(string(e))

--- a/primitive/hash.go
+++ b/primitive/hash.go
@@ -1,7 +1,5 @@
 package primitive
 
-import "fmt"
-
 // Hash holds a collection of other types, indexed by string
 type Hash struct {
 
@@ -68,5 +66,5 @@ func (h Hash) Type() string {
 	if h.StructType == "" {
 		return "hash"
 	}
-	return fmt.Sprintf("struct-%s", h.StructType)
+	return h.StructType
 }

--- a/primitive/hash.go
+++ b/primitive/hash.go
@@ -13,6 +13,12 @@ type Hash struct {
 	StructType string
 }
 
+// IsSimpleType is used to denote whether this object
+// is self-evaluating.
+func (h Hash) IsSimpleType() bool {
+	return true
+}
+
 // SetStruct marks this as a "struct" type instead of a "hash type",
 // when queried by lisp
 func (h *Hash) SetStruct(name string) {

--- a/primitive/hash.go
+++ b/primitive/hash.go
@@ -13,23 +13,6 @@ type Hash struct {
 	StructType string
 }
 
-// IsSimpleType is used to denote whether this object
-// is self-evaluating.
-func (h Hash) IsSimpleType() bool {
-	return true
-}
-
-// SetStruct marks this as a "struct" type instead of a "hash type",
-// when queried by lisp
-func (h *Hash) SetStruct(name string) {
-	h.StructType = name
-}
-
-// GetStruct returns the name of the structure this object contains, if any
-func (h *Hash) GetStruct() string {
-	return h.StructType
-}
-
 // Get returns the value of a given index
 func (h Hash) Get(key string) Primitive {
 	x, ok := h.Entries[key]
@@ -37,6 +20,17 @@ func (h Hash) Get(key string) Primitive {
 		return x
 	}
 	return Nil{}
+}
+
+// GetStruct returns the name of the structure this object contains, if any
+func (h *Hash) GetStruct() string {
+	return h.StructType
+}
+
+// IsSimpleType is used to denote whether this object
+// is self-evaluating.
+func (h Hash) IsSimpleType() bool {
+	return true
 }
 
 // NewHash creates a new hash, and ensures that the storage-space
@@ -50,6 +44,12 @@ func NewHash() Hash {
 // Set stores a value in the hash
 func (h Hash) Set(key string, val Primitive) {
 	h.Entries[key] = val
+}
+
+// SetStruct marks this as a "struct" type instead of a "hash type",
+// when queried by lisp
+func (h *Hash) SetStruct(name string) {
+	h.StructType = name
 }
 
 // ToString converts this object to a string.

--- a/primitive/hash_test.go
+++ b/primitive/hash_test.go
@@ -19,6 +19,10 @@ func TestHash(t *testing.T) {
 		t.Fatalf("got wrong value")
 	}
 
+	if !h.IsSimpleType() {
+		t.Fatalf("expected has to be a simple type")
+	}
+
 	if h.Type() != "hash" {
 		t.Fatalf("Wrong type for hash")
 	}

--- a/primitive/list.go
+++ b/primitive/list.go
@@ -5,6 +5,12 @@ import "strings"
 // List holds a collection of other types, including Lists.
 type List []Primitive
 
+// IsSimpleType is used to denote whether this object
+// is self-evaluating.
+func (l List) IsSimpleType() bool {
+	return false
+}
+
 // ToString converts this object to a string.
 func (l List) ToString() string {
 	elemStrings := []string{}

--- a/primitive/nil.go
+++ b/primitive/nil.go
@@ -3,6 +3,12 @@ package primitive
 // Nil type holds the undefined value
 type Nil struct{}
 
+// IsSimpleType is used to denote whether this object
+// is self-evaluating.
+func (n Nil) IsSimpleType() bool {
+	return true
+}
+
 // ToInterface converts this object to a golang value
 func (n Nil) ToInterface() any {
 	return nil

--- a/primitive/number.go
+++ b/primitive/number.go
@@ -7,6 +7,12 @@ import (
 // Number type holds numbers.
 type Number float64
 
+// IsSimpleType is used to denote whether this object
+// is self-evaluating.
+func (n Number) IsSimpleType() bool {
+	return true
+}
+
 // ToInterface converts this object to a golang value
 func (n Number) ToInterface() any {
 

--- a/primitive/primitive.go
+++ b/primitive/primitive.go
@@ -5,6 +5,15 @@ package primitive
 // Primitive is the interface of all our types
 type Primitive interface {
 
+	// IsSimpleType is used to denote whether this object
+	// is self-evaluating.
+	//
+	// Simple types include strings, numbers, booleans, etc.
+	//
+	// However note that a list is NOT a simple type, as it
+	// is used to denote a function-call.
+	IsSimpleType() bool
+
 	// ToString converts this primitive to a string representation.
 	ToString() string
 

--- a/primitive/primitive_test.go
+++ b/primitive/primitive_test.go
@@ -11,6 +11,10 @@ func TestBool(t *testing.T) {
 	true := Bool(true)
 	false := Bool(false)
 
+	if !true.IsSimpleType() {
+		t.Fatalf("expected boolean to be a simple type")
+	}
+
 	if true.Type() != "boolean" {
 		t.Fatalf("wrong type")
 	}
@@ -48,6 +52,10 @@ func TestCharacter(t *testing.T) {
 	ok := Character("o")
 	empty := Character("")
 
+	if !nl.IsSimpleType() {
+		t.Fatalf("expected character to be a simple type")
+	}
+
 	if nl.Type() != "character" {
 		t.Fatalf("wrong type")
 	}
@@ -82,6 +90,10 @@ func TestError(t *testing.T) {
 
 	error := Error("no-cheese")
 
+	if !error.IsSimpleType() {
+		t.Fatalf("expected error to be a simple type")
+	}
+
 	if error.Type() != "error" {
 		t.Fatalf("wrong type")
 	}
@@ -91,6 +103,10 @@ func TestError(t *testing.T) {
 
 	if !strings.Contains(ArityError().ToString(), "Arity") {
 		t.Fatalf("arity-error is non-obvious")
+	}
+
+	if !strings.Contains(TypeError("xx").ToString(), "TypeError") {
+		t.Fatalf("TypeError is non-obvious")
 	}
 
 	//
@@ -106,6 +122,10 @@ func TestError(t *testing.T) {
 func TestIsNil(t *testing.T) {
 
 	var n Nil
+
+	if !n.IsSimpleType() {
+		t.Fatalf("expected nil to be a simple type")
+	}
 
 	if n.Type() != "nil" {
 		t.Fatalf("nil -> wrong type")
@@ -144,6 +164,10 @@ func TestList(t *testing.T) {
 		Number(3),
 	})
 
+	if lst.IsSimpleType() {
+		t.Fatalf("Did not expect list to be a simple type")
+	}
+
 	if lst.Type() != "list" {
 		t.Fatalf("wrong type")
 	}
@@ -156,6 +180,10 @@ func TestNumber(t *testing.T) {
 
 	i := Number(3)
 	f := Number(1.0 / 9)
+
+	if !i.IsSimpleType() {
+		t.Fatalf("expected number to be a simple type")
+	}
 
 	if i.Type() != "number" {
 		t.Fatalf("wrong type")
@@ -192,6 +220,10 @@ func TestString(t *testing.T) {
 
 	str := String("i like cake")
 
+	if !str.IsSimpleType() {
+		t.Fatalf("expected string to be a simple type")
+	}
+
 	if str.Type() != "string" {
 		t.Fatalf("wrong type")
 	}
@@ -204,6 +236,9 @@ func TestSymbol(t *testing.T) {
 
 	sym := Symbol("pi")
 
+	if sym.IsSimpleType() {
+		t.Fatalf("did not expected symbol to be a simple type")
+	}
 	if sym.Type() != "symbol" {
 		t.Fatalf("wrong type")
 	}

--- a/primitive/procedure.go
+++ b/primitive/procedure.go
@@ -34,6 +34,12 @@ type Procedure struct {
 	Macro bool
 }
 
+// IsSimpleType is used to denote whether this object
+// is self-evaluating.
+func (p *Procedure) IsSimpleType() bool {
+	return false
+}
+
 // ToString converts this object to a string.
 func (p *Procedure) ToString() string {
 	if p.F != nil {

--- a/primitive/procedure_test.go
+++ b/primitive/procedure_test.go
@@ -1,6 +1,8 @@
 package primitive
 
-import ( "testing"
+import (
+	"testing"
+
 	"github.com/skx/yal/env"
 )
 
@@ -8,7 +10,7 @@ func TestProcedure(t *testing.T) {
 
 	// built-in
 	b := Procedure{
-		F: func(e *env.Environment,args []Primitive) Primitive {
+		F: func(e *env.Environment, args []Primitive) Primitive {
 			return Nil{}
 		},
 	}
@@ -40,6 +42,10 @@ func TestProcedure(t *testing.T) {
 		},
 	}
 
+	if b.IsSimpleType() {
+		t.Fatalf("did not expect built-in to be a simple type")
+	}
+
 	if b.Type() != "procedure(golang)" {
 		t.Fatalf("wrong type for builtin")
 	}
@@ -53,11 +59,17 @@ func TestProcedure(t *testing.T) {
 	if l.ToString() != "(lambda (A B) (+ A B))" {
 		t.Fatalf("wrong string-type for lisp-proc, got %s", l.ToString())
 	}
+	if l.IsSimpleType() {
+		t.Fatalf("did not expect proc to be a simple type")
+	}
 
 	if m.Type() != "macro" {
 		t.Fatalf("wrong type for lisp macro")
 	}
 	if m.ToString() != "(macro (A B) (+ A B))" {
 		t.Fatalf("wrong string-type for macro, got %s", m.ToString())
+	}
+	if m.IsSimpleType() {
+		t.Fatalf("did not expect macro to be a simple type")
 	}
 }

--- a/primitive/string.go
+++ b/primitive/string.go
@@ -3,6 +3,12 @@ package primitive
 // String holds a string value.
 type String string
 
+// IsSimpleType is used to denote whether this object
+// is self-evaluating.
+func (s String) IsSimpleType() bool {
+	return true
+}
+
 // ToString converts this object to a string.
 func (s String) ToString() string {
 	return string(s)

--- a/primitive/symbol.go
+++ b/primitive/symbol.go
@@ -3,6 +3,12 @@ package primitive
 // Symbol is the type for our symbols.
 type Symbol string
 
+// IsSimpleType is used to denote whether this object
+// is self-evaluating.
+func (s Symbol) IsSimpleType() bool {
+	return false
+}
+
 // ToInterface converts this object to a golang value
 func (s Symbol) ToInterface() any {
 	return s.ToString()


### PR DESCRIPTION
This commit is the first in a chain that will close #94, by simplifying our eval method.

Here we've recognized that all of our simple types return themselves when they're evaluated - so we've created a simple "IsSimpleType" in our primitive interface.

This makes it easy for simple things to return themselves, and no longer need to have a special case.