### PR TITLE
Added -debug flag, writing to STDERR.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,20 +3,27 @@
 // are not necessarily terminal-based.
 //
 // All input-reading uses the level of indirection provided here, and
-// similarly output goes via the writer we hold here.
+// similarly output goes via the writer we hold here. There is also a
+// STDERR stream which is used for (optional) debugging output by our
+// main driver.
 //
-// This abstraction allows a host program to setup a different pair of
-// streams prior to initializing the interpreter.
+// The I/O abstraction allows a host program to setup different streams
+// prior to initializing the interpreter.
 package config
 
 import (
 	"io"
+	"io/ioutil"
 	"os"
 )
 
 // Config is a holder for configuration which is used for interfacing
 // the interpreter with the outside world.
 type Config struct {
+
+	// STDERR is the writer for debug output, by default output
+	// sent here is discarded.
+	STDERR io.Writer
 
 	// STDIN is an input-reader used for the (read) function, when
 	// called with no arguments.
@@ -35,13 +42,20 @@ func New() *Config {
 
 // DefaultIO returns a configuration which uses the default
 // input and output streams - i.e. STDIN and STDOUT work as
-// expected
+// expected.
+//
+// The STDERR writer is configured to discard output by default.
 func DefaultIO() *Config {
 	e := New()
 
-	// Setup default input/output streams
+	// Setup useful input/output streams for default usage.
 	e.STDIN = os.Stdin
 	e.STDOUT = os.Stdout
+
+	// STDERR is only used when debugging.
+	//
+	// So we can discard output here by default.
+	e.STDERR = ioutil.Discard
 
 	return e
 }

--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,6 @@ package config
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -55,7 +54,7 @@ func DefaultIO() *Config {
 	// STDERR is only used when debugging.
 	//
 	// So we can discard output here by default.
-	e.STDERR = ioutil.Discard
+	e.STDERR = io.Discard
 
 	return e
 }

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -506,6 +506,9 @@ func TestStandardLibrary(t *testing.T) {
 			// Populate the default primitives
 			builtins.PopulateEnvironment(env)
 
+			// Environment will have a config
+			env.SetIOConfig(config.DefaultIO())
+
 			// Run it
 			out := l.Evaluate(env)
 
@@ -543,6 +546,9 @@ func TestStdlibHelp(t *testing.T) {
 
 	// Populate the default primitives
 	builtins.PopulateEnvironment(env)
+
+	// Environment will have a config
+	env.SetIOConfig(config.DefaultIO())
 
 	// Run it
 	_ = l.Evaluate(env)
@@ -594,6 +600,9 @@ func TestTimeout(t *testing.T) {
 
 	// With a new environment
 	ev := env.New()
+
+	// Environment will have a config
+	ev.SetIOConfig(config.DefaultIO())
 
 	// Add a new function
 	ev.Set("sleep",

--- a/main.go
+++ b/main.go
@@ -205,6 +205,8 @@ func main() {
 	hlp := flag.Bool("h", false, "Show help information and exit.")
 	lsp := flag.Bool("lsp", false, "Launch the LSP mode")
 	ver := flag.Bool("v", false, "Show our version and exit.")
+	deb := flag.Bool("debug", false, "Show debug output during execution (to STDERR).")
+
 	flag.Parse()
 
 	// Showing the version?
@@ -227,6 +229,23 @@ func main() {
 	//     that present too.
 	//
 	create()
+
+
+	//
+	// By default we have no STDERR handler wired up, but if we set the
+	// debug flag we'll send that to the actual console's STDERR stream
+	if *deb {
+
+		// Get config
+		iohelper := ENV.GetIOConfig()
+
+		// Setup a destination for STDERR
+		iohelper.STDERR =os.Stderr
+
+		// Update
+		ENV.SetIOConfig(iohelper)
+	}
+
 
 	// LSP?
 	if *lsp {


### PR DESCRIPTION
Since we have the I/O indirection for STDIN and STDOUT it makes sense to add the same for STDERR.  Of course we don't have anything going there by default, so I've added a -debug flag to make it useful.

For the moment I'm logging the output of macro-expansion, but it probably makes sense to log other things instead/as well.  Or remove it.

Ideally our lisp would be able to write to STDOUT and STDERR, but then we get into adding support for streams and files.  That might be next..?