### PR TITLE
When converting hashes to strings, sort their keys first.

### DIFF
--- a/.github/run-tests.sh
+++ b/.github/run-tests.sh
@@ -37,6 +37,8 @@ echo "Launching shadowed-variable check .."
 go vet -vettool=$(which shadow) ./...
 echo "Completed shadowed-variable check .."
 
+go env -w GOFLAGS="-buildvcs=false"
+
 # Run golang tests
 go test ./...
 

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -278,6 +278,12 @@ a
 		{"(* 4 -1)", "-4"},
 		{"(# 3 2)", "9"},
 
+		// hash equality
+		{`(eq { :name "Ale" :age 3}
+                      { :age 3 :name "Ale"})`, "#t"},
+		{`(eq { :name "ale" :age 3}
+                      { :age 3 :name "Ale"})`, "#f"},
+
 		// since we're variadic we start with the first
 		// number, and apply the operation to any subsequent
 		// ones.

--- a/primitive/hash.go
+++ b/primitive/hash.go
@@ -1,5 +1,7 @@
 package primitive
 
+import "sort"
+
 // Hash holds a collection of other types, indexed by string
 type Hash struct {
 
@@ -51,12 +53,32 @@ func (h *Hash) SetStruct(name string) {
 }
 
 // ToString converts this object to a string.
+//
+// Note that we sort the keys before returning the stringified object,
+// which allows us to use the "eq" test on hashes with identical key/values,
+// regardless of their ordering.
 func (h Hash) ToString() string {
 
+	// Output prefix.
 	out := "{\n"
-	for k, v := range h.Entries {
-		out += "\t" + k + " => " + v.ToString() + "\n"
+
+	// Get the keys in our hash.
+	keys := []string{}
+
+	for x := range h.Entries {
+		keys = append(keys, x)
 	}
+
+	// Sort the list of keys
+	sort.Strings(keys)
+
+	// Now we can get a consistent ordering for our
+	// hash keys/value pairs.
+	for _, key := range keys {
+		out += "\t" + key + " => " + h.Entries[key].ToString() + "\n"
+	}
+
+	// Terminate the string representation and return.
 	out += "}"
 	return out
 }


### PR DESCRIPTION
This allows the following code to return "true" as expected:

```
(print (eq
        { :name "Ale" :age 3 :colors [:red :green :blue] }
        { :colors [:red :green :blue] :age 3 :name "Ale" }))
```