### PR TITLE
Allow default arguments

### DIFF
--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -115,6 +115,23 @@ Help information can be retrieved at runtime, for usage:
 
     (print (help print))
 
+As shown in the examples above parameters are named, rather than specifying
+them as distinct symbols it is also possible to specify a default value by
+expressing the parameters as a list (of two items only):
+
+    (set! greet (fn* ( (name "World") )
+      "Greet the supplied name, use the default if a name is not supplied."
+      (print "Hello, %s" name)))
+
+That would operate like so:
+
+    (greet "Steve") ; "Hello, Steve"
+    (greet)         ; "Hello, World"
+
+
+
+
+## Macros
 To define a macro use `defmacro!`:
 
     (defmacro! debug (fn* (x) `(print "Variable '%s' has value %s" '~x ~x)))

--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -56,12 +56,12 @@ You can receive a full-list of special forms via `(specials)`, this list will in
 * `def!`
   * `define` is an alias.
 * `defmacro!`
-  * Demonstrated in [mtest.lisp](mtest.lisp).
+  * Demonstrated in [examples/mtest.lisp](examples/mtest.lisp).
 * `do`
   * Execute each statement in the list.
 * `env`
   * Env allows introspection of the current environment.
-  * Demonstrated in [dynamic.lisp](dynamic.lisp)
+  * Demonstrated in [examples/dynamic.lisp](examples/dynamic.lisp)
 * `eval`
   * Execute the given expression.
 * `fn*`
@@ -90,7 +90,7 @@ You can receive a full-list of special forms via `(specials)`, this list will in
 * `symbol`
   * Create a new symbol from the given string.
 * `try`
-  * Error-catching warpper, demonstrated in [try.lisp](try.lisp).
+  * Error-catching warpper, demonstrated in [examples/try.lisp](examples/try.lisp).
 
 
 ## Core Primitives
@@ -157,7 +157,7 @@ You can receive a full-list of these via `(builtins)`, this list will include:
   * Trig. function.
 * `date`
   * Return details of today's date, as a list.
-  * Demonstrated in [time.lisp](time.lisp).
+  * Demonstrated in [examples/time.lisp](examples/time.lisp).
 * `dec2bin`
   * Convert the specified integer to a binary string.
 * `dec2hex`
@@ -270,7 +270,7 @@ You can receive a full-list of these via `(builtins)`, this list will include:
   * Trig. function.
 * `time`
   * Return values relating to the current time, as a list.
-  * Demonstrated in [time.lisp](time.lisp).
+  * Demonstrated in [examples/time.lisp](examples/time.lisp).
 * `type`
   * Return the type of the given object.
 * `vals`

--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -52,7 +52,7 @@ You can receive a full-list of special forms via `(specials)`, this list will in
 * `alias`
   * Define function aliases, this is used whenever we rename/change things in the standard-library to avoid breaking user scripts.
 * `catch`.
-  * Demonstrated in [try.lisp](try.lisp).
+  * Demonstrated in [examples/try.lisp](examples/try.lisp).
 * `def!`
   * `define` is an alias.
 * `defmacro!`

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -1071,6 +1071,15 @@ func helpFn(env *env.Environment, args []primitive.Primitive) primitive.Primitiv
 			str = "Arguments"
 		}
 		str += " " + arg.ToString()
+
+		// Default value for this argument?
+		def, ok2 := proc.Defaults[arg]
+		if ok2 {
+			str += "[default:"
+			str += def.ToString()
+			str += "]"
+		}
+
 	}
 	if len(str) > 0 {
 		str += "\n"

--- a/builtins/builtins_test.go
+++ b/builtins/builtins_test.go
@@ -2003,7 +2003,7 @@ func TestHelp(t *testing.T) {
 	env := env.New()
 	PopulateEnvironment(env)
 
-	for _, name := range []string{"print", "sprintf", "length"} {
+	for _, name := range []string{"print", "sprintf", "length", "inc", "dec"} {
 
 		// Load our standard library
 		st := stdlib.Contents()

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -605,13 +605,18 @@ func (ev *Eval) eval(exp primitive.Primitive, e *env.Environment, expandMacro bo
 		// Variadic arguments would add _extra_ arguments, so this check
 		// is still safe for those.
 		//
-		if len(args) < min {
+		if (len(args) + len(proc.Defaults)) < min {
 			return primitive.ArityError()
 		}
 
 		// Create a new environment/scope to set the
 		// parameter values within.
 		e = env.NewEnvironment(proc.Env)
+
+		// For each default argument set it
+		for k, v := range proc.Defaults {
+			e.Set(k.ToString(),v)
+		}
 
 		// For each of the arguments that have been supplied
 		for i, x := range args {

--- a/examples/lisp-tests.lisp
+++ b/examples/lisp-tests.lisp
@@ -448,6 +448,16 @@ If the name of the test is not unique then that will cause an error to be printe
 (deftest find:3 (list (find 3 '(1 2 3 3 2 1 )) '(2 3 )))
 (deftest find:4 (list (find 3 '()) nil))
 
+
+;; defaults
+(set! addy (fn* ( (a 10) (b 11) ) (+ a b) ))
+
+(deftest defaults:1 (list (addy)       21))
+(deftest defaults:2 (list (addy 1)     12))
+(deftest defaults:3 (list (addy 1 2)    3))
+(deftest defaults:4 (list (addy 1 2 3)  3))
+
+
 ;; Define two helpers for sorting, by one/other field.
 (set! people-surname-sort (fn* (a b) (string< (person.surname a) (person.surname b))))
 (set! people-forename-sort (fn* (a b) (string< (person.forename a) (person.forename b))))

--- a/main.go
+++ b/main.go
@@ -162,6 +162,14 @@ func help(show []string) {
 
 			for _, arg := range prc.Args {
 				args += " " + arg.ToString()
+
+				// Default value for this argument?
+				def, ok := prc.Defaults[arg]
+				if ok {
+					args += "[default:"
+					args += def.ToString()
+					args += "]"
+				}
 			}
 			args = strings.TrimSpace(args)
 			args = " (" + args + ")"

--- a/primitive/procedure.go
+++ b/primitive/procedure.go
@@ -15,6 +15,9 @@ type Procedure struct {
 	// Arguments to this procedure.
 	Args []Symbol
 
+	// Defaults supplied when the procedure was defined
+	Defaults map[Symbol]Primitive
+
 	// Body is the body to execute, in the case where F is nil.
 	Body Primitive
 

--- a/stdlib/stdlib/lists.lisp
+++ b/stdlib/stdlib/lists.lisp
@@ -1,6 +1,6 @@
 ;;; lists.lisp - Some list-utility functions
 
-;; These were adapted from Rob Pike's lisp
+;; Some of these functions were adapted from Rob Pike's lisp
 ;;
 ;;    https://github.com/robpike/lisp
 ;;

--- a/stdlib/stdlib/logical.lisp
+++ b/stdlib/stdlib/logical.lisp
@@ -16,7 +16,9 @@
 ;: If the length of the input list, and the length of the filtered list
 ;; are the same then EVERY element was true so our AND result is true.
 (set! and (fn* (xs:list)
-               "Return true if every item in the specified list is true."
+               "Return true if every item in the specified list is true.
+
+NOTE: This is not a macro, so all arguments are evaluated."
                (let* (res nil)
                  (set! res (filter xs (lambda (x) (if x true false))))
                  (if (= (length res) (length xs))
@@ -32,7 +34,9 @@
 ;; If the output list has at least one element that was true then the
 ;; OR result is true.
 (set! or (fn* (xs:list)
-              "Return true if any value in the specified list contains a true value."
+              "Return true if any value in the specified list contains a true value.
+
+NOTE: This is not a macro, so all arguments are evaluated."
               (let* (res nil)
                 (set! res (filter xs (lambda (x) (if x true false))))
                 (if (> (length res) 0)
@@ -44,7 +48,9 @@
 
 ;; every is useful and almost a logical operation
 (set! every (fn* (xs:list fun:function)
-                 "Return true if applying every element of the list through the specified function resulted in a true result."
+                 "Return true if applying every element of the list through the specified function resulted in a true result.
+
+NOTE: This is not a macro, so all arguments are evaluated."
                  (let* (res (map xs fun))
                    (if (and res)
                        true

--- a/stdlib/stdlib/mal.lisp
+++ b/stdlib/stdlib/mal.lisp
@@ -28,7 +28,7 @@ It is similar to an if-statement, however there is no provision for an 'else' cl
 ;; NOTE: This recurses, so it will eventually explode the stack.
 ;;
 (defmacro! while (fn* (condition &body)
-                      "while is a macro which repeatedly runs the specified body, while the condition returns a true-result"
+                      "while is a macro which repeatedly runs the specified body, while the condition returns a true-result."
                       (let* (inner-sym (gensym))
                         `(let* (~inner-sym (fn* ()
                                                 (if ~condition

--- a/stdlib/stdlib/maths.lisp
+++ b/stdlib/stdlib/maths.lisp
@@ -1,13 +1,17 @@
 ;;; maths.lisp - Some simple maths-related primitives
 
 ;; inc/dec are useful primitives to have
-(set! inc (fn* (n:number)
-               "inc will add one to the supplied value, and return the result."
-               (+ n 1)))
+(set! inc (fn* (n:number (by 1))
+               "inc will add one to the supplied value, and return the result.
 
-(set! dec (fn* (n:number)
-               "dec will subtract one from the supplied value, and return the result."
-               (- n 1)))
+If the optional second value is supplied it will be used instead of one."
+               (+ n by)))
+
+(set! dec (fn* (n:number (by 1))
+               "dec will subtract one from the supplied value, and return the result.
+
+If the optional second value is supplied it will be used instead of one."
+               (- n by)))
 
 ;; PI
 (set! pi (fn* ()


### PR DESCRIPTION
We typically define a function like this:

     (set! hello1 (fn* (name)
       (print "Hello %s" name)))

Here we say there is a parameter "name" which must be supplied, and that is later used.

If we instead say that parameters can be lists we can allow the first value to be the name, and the second a default value if nothing is actually passed, like so:

     (set! hello2 (fn* ( (name "World") )
        (print "Hello %s"  name)))

These could be used like so:

     (hello1 "Steve")  ; "Hello Steve"

     (hello2 "Steve")  ; "Hello Steve"
     (hello2)          ; "Hello World"

I've not yet experimented with supplying defaults in the non-final arguments, because that could screw things up.  But for simple cases like the one above it seems to work.

Once complete this will close #130, however I need to add test-cases..