### PR TITLE
Allow setting the help-text, by name, as well as retrieving it

### DIFF
--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -1075,9 +1075,38 @@ func globFn(env *env.Environment, args []primitive.Primitive) primitive.Primitiv
 
 // helpFn is the implementation of `(help fn)`
 func helpFn(env *env.Environment, args []primitive.Primitive) primitive.Primitive {
+
+	// Two arguments?
+	if len(args) == 2 {
+
+		name, ok1 := args[0].(primitive.String)
+		help, ok2 := args[1].(primitive.String)
+
+		if !ok1 {
+			return primitive.Error("when setting help the key must be a string")
+		}
+		if !ok2 {
+			return primitive.Error("when setting help the value must be a string")
+		}
+
+		helpMap[name.ToString()] = help.ToString()
+		return primitive.Nil{}
+	}
+
 	// We need a single argument
 	if len(args) != 1 {
 		return primitive.ArityError()
+	}
+
+	// Lookup by string?
+	name, ok1 := args[0].(primitive.String)
+	if ok1 {
+		// Stored at runtime?
+		out, ok := helpMap[name.ToString()]
+		if ok {
+			return primitive.String(out)
+		}
+		return primitive.Nil{}
 	}
 
 	// Which is a function

--- a/builtins/builtins_shell_test.go
+++ b/builtins/builtins_shell_test.go
@@ -37,6 +37,19 @@ func TestShell(t *testing.T) {
 		t.Fatalf("got error, but wrong one %v", out)
 	}
 
+	// One argument, but an empty list, not a valid one.
+	out = shellFn(ENV, []primitive.Primitive{
+		primitive.List{},
+	})
+
+	e, ok = out.(primitive.Error)
+	if !ok {
+		t.Fatalf("expected error, got %v", out)
+	}
+	if !strings.Contains(e.ToString(), "must be non-empty") {
+		t.Fatalf("got error, but wrong one %v", out)
+	}
+
 	// Echo command to execute.
 	cmd := primitive.List{}
 	cmd = append(cmd, primitive.String("echo"))

--- a/builtins/builtins_test.go
+++ b/builtins/builtins_test.go
@@ -2058,9 +2058,9 @@ func TestHelp(t *testing.T) {
 		t.Fatalf("got error, but wrong one")
 	}
 
-	// First argument must be a procedure
+	// First argument must be a procedure or string
 	out = helpFn(ENV, []primitive.Primitive{
-		primitive.String("foo"),
+		primitive.Number(3),
 	})
 
 	// Will lead to an error
@@ -2103,6 +2103,56 @@ func TestHelp(t *testing.T) {
 		if !strings.Contains(txt.ToString(), name) {
 			t.Fatalf("got help text, but didn't find expected content: %v", result)
 		}
+	}
+
+	// Two argument form of help is acceptible - if both args are string
+	out = helpFn(ENV, []primitive.Primitive{
+		primitive.String("OK"),
+		primitive.Number(3),
+	})
+	// Will lead to an error
+	e, ok = out.(primitive.Error)
+	if !ok {
+		t.Fatalf("expected error, got %v", out)
+	}
+	if !strings.Contains(string(e), "must be a string") {
+		t.Fatalf("got error, but wrong one")
+	}
+
+	// Two argument form of help is acceptible - if both args are string
+	out = helpFn(ENV, []primitive.Primitive{
+		primitive.Number(3),
+		primitive.String("OK"),
+	})
+	// Will lead to an error
+	e, ok = out.(primitive.Error)
+	if !ok {
+		t.Fatalf("expected error, got %v", out)
+	}
+	if !strings.Contains(string(e), "must be a string") {
+		t.Fatalf("got error, but wrong one")
+	}
+
+	// Retrieve it
+	out = helpFn(ENV, []primitive.Primitive{
+		primitive.String("Foo"),
+	})
+	if out.ToString() != "nil" {
+		t.Fatalf("failed to confirm missing hlep string")
+	}
+
+	// Setup a help string
+	out = helpFn(ENV, []primitive.Primitive{
+		primitive.String("Foo"),
+		primitive.String("Bar"),
+	})
+
+	// Retrieve it
+	out = helpFn(ENV, []primitive.Primitive{
+		primitive.String("Foo"),
+	})
+	if out.ToString() != "Bar" {
+		t.Fatalf("failed to setup a custom help-string")
 	}
 }
 

--- a/builtins/builtins_test.go
+++ b/builtins/builtins_test.go
@@ -2089,15 +2089,15 @@ func TestHelp(t *testing.T) {
 
 		l.Evaluate(env)
 
-		fn, ok := env.Get(name)
-		if !ok {
+		fn, ok2 := env.Get(name)
+		if !ok2 {
 			t.Fatalf("failed to lookup function %s in environment", name)
 		}
 
 		result := helpFn(ENV, []primitive.Primitive{fn.(*primitive.Procedure)})
 
-		txt, ok2 := result.(primitive.String)
-		if !ok2 {
+		txt, ok3 := result.(primitive.String)
+		if !ok3 {
 			t.Fatalf("expected a string, got %v", result)
 		}
 		if !strings.Contains(txt.ToString(), name) {

--- a/builtins/builtins_test.go
+++ b/builtins/builtins_test.go
@@ -2142,7 +2142,7 @@ func TestHelp(t *testing.T) {
 	}
 
 	// Setup a help string
-	out = helpFn(ENV, []primitive.Primitive{
+	helpFn(ENV, []primitive.Primitive{
 		primitive.String("Foo"),
 		primitive.String("Bar"),
 	})


### PR DESCRIPTION
This is going to be required at the point that I start thinking about native functions.

I want to replace "(sin)" with "(math.Sin)" (golang), which means that I no longer have a place to set the text.  Something like this:

```lisp
(alias sin math.Sin)
(help "sin" "Sin returns the sine of the radian argument.")
```

Unfortunately this means extending things so that `(help sin)` and `(help "sin")` are interchangeable - as at the point we have migrated we'll not have a sin-symbol to resolve, and even if we did it would not be a primitive.Procedure.

This is a trivial thing until I've actually implemented the reflection/go-based stuff which is tracked in #139, but it seems like it is going to be necessary.