### PR TITLE
Coerce arguments to functions, in some cases

### DIFF
--- a/.github/run-tests.sh
+++ b/.github/run-tests.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# I don't even ..
+go env -w GOFLAGS="-buildvcs=false"
+
+
 # Install the tools we use to test our code-quality.
 #
 # Here we setup the tools to install only if the "CI" environmental variable
@@ -36,9 +40,6 @@ echo "Completed linter .."
 echo "Launching shadowed-variable check .."
 go vet -vettool=$(which shadow) ./...
 echo "Completed shadowed-variable check .."
-
-# I don't even ..
-go env -w GOFLAGS="-buildvcs=false"
 
 # Run golang tests
 go test ./...


### PR DESCRIPTION
This is a bit of a sneaky change, but it is useful to convert arguments to lists in some cases:

* If a function is defined that accepts a single parameter.
* BUT multiple arguments are actually passed to that function
* THEN
  * If the parameter is not variadic
  * And the parameter is untyped, or typed as a list
  * REPLACE THE Arguments with a list containing their entries.

This means:

    (set! and (fn* (xs:list) ... )

Can then be called:

    (and true false true true ..)

Because the arguments will be rewritten as if they were called:

    (and (list true false true true ..)

This is general purpose, and applies to all functions.

I _think_ it's a good idea, but we'll see.