### PR TITLE
fixed scoping to behave as expected

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -9,7 +9,9 @@
 // or call-frames, you can create a nested environment via NewEnvironment.
 package env
 
-import "github.com/skx/yal/config"
+import (
+	"github.com/skx/yal/config"
+)
 
 // Environment holds our state
 type Environment struct {
@@ -85,15 +87,23 @@ func (env *Environment) Set(key string, value any) {
 	env.values[key] = value
 }
 
-// SetOuter sets the variable in the parent scope, if not present in this one.
-func (env *Environment) SetOuter(key string, value any) {
+// SetInDefinition sets the variable where it is defined, and returns true.
+// If the value is not defined anywhere then we return false.
+func (env *Environment) SetInDefinition(key string, value any) bool {
+
+	// Is it set in this scope?
 	if _, ok := env.values[key]; ok {
+
+		// Then update and return success
 		env.values[key] = value
-		return
+		return true
 	}
 	if env.parent != nil {
-		env.parent.SetOuter(key, value)
+		if env.parent.SetInDefinition(key, value) {
+			return true
+		}
 	}
+	return false
 }
 
 // SetIOConfig updates the configuration object which is stored

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -77,35 +77,4 @@ func TestScopedSet(t *testing.T) {
 		t.Fatalf("got variable; wrong value")
 	}
 
-	// Set variable in child
-	c.Set("NAME", "STEVE")
-	//	c.SetOuter("NAME", "STEVE")
-
-	// child should get it
-	val, ok = c.Get("NAME")
-	if !ok {
-		t.Fatalf("failed to get child-variable in child")
-	}
-	if val.(string) != "STEVE" {
-		t.Fatalf("variable had wrong value")
-	}
-
-	// parent should not
-	_, ok = p.Get("NAME")
-	if ok {
-		t.Fatalf("shouldn't be able to get child-variable in parent")
-	}
-
-	// set in the child
-	//
-	// Will actually set in the parent
-	c.SetOuter("FOO", "BART")
-
-	val, ok = p.Get("FOO")
-	if !ok {
-		t.Fatalf("parent-child weirdness")
-	}
-	if val.(string) != "BART" {
-		t.Fatalf("parent-child set failed")
-	}
 }

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -198,7 +198,7 @@ func TestEvaluate(t *testing.T) {
   (set! a 4321))
 a
 `,
-			"3"},
+			"4321"},
 
 		// (set! a b TRUE) inside (let) will modify the parent scope
 		{`
@@ -331,7 +331,7 @@ a
 		// we have a LOT of built ins, but not 200
 		{"(> (length (env))     10)", "#t"},
 		{"(> (length (env))     50)", "#t"},
-		{"(< (length (env))    200)", "#t"},
+		{"(< (length (env))    500)", "#t"},
 		{"(< (length (stdlib)) 200)", "#t"},
 
 		// errors

--- a/eval/specials.go
+++ b/eval/specials.go
@@ -523,12 +523,22 @@ func (ev *Eval) evalSpecialForm(name string, args []primitive.Primitive, e *env.
 			}
 		}
 
-		// Now set, either locally or in the parent scope.
-		if len(args) == 3 {
-			e.SetOuter(string(sym), val)
-		} else {
-			e.Set(string(sym), val)
+		//
+		// Okay what we do here will be a little wierd and non-standard
+		//
+		// We want to see if the variable exists in the current scope,
+		// if not we want to search upwards.
+		//
+		// We ONLY set the value in the scope in which it is defined.
+		//
+		v := e.SetInDefinition(string(sym), val)
+		if v {
+			// we set it
+			return primitive.Nil{}, true
 		}
+
+		// We didn't set it, create the variable in the current scope.
+		e.Set(string(sym), val)
 		return primitive.Nil{}, true
 
 	case "stdlib":

--- a/stdlib/stdlib/mal.lisp
+++ b/stdlib/stdlib/mal.lisp
@@ -41,6 +41,7 @@ It is similar to an if-statement, however there is no provision for an 'else' cl
 ;;       (foo n)))
 ;;
 (defmacro! loop (fn* (vr xs bdy)
+                     "loop allows executing a block of code with a single variable bound to an item from the supplied list."
                     (let* (inner-sym (gensym))
                     `(list
                        (let* (~inner-sym (fn* (~vr) (~@bdy)))


### PR DESCRIPTION
(set!) now works in a way that I think makes sense - it sets the variable in the scope in which it is defined.

So if inside a (let*) block we set it there, otherwise we set it in the parent scope.

This belatedly closes #22.